### PR TITLE
main user journey synced with live service

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -79,3 +79,31 @@ $(document).ready(function() {
   });
 
 });
+// Set month names
+var monthNames = [
+  "January", "February", "March",
+  "April", "May", "June", "July",
+  "August", "September", "October",
+  "November", "December"
+];
+
+var monthNamesShort = [
+  "Jan", "Feb", "Mar",
+  "Apr", "May", "Jun", "Jul",
+  "Aug", "Sep", "Oct",
+  "Nov", "Dec"
+];
+
+// Show current date
+date = new Date();
+y = date.getFullYear();
+m = date.getMonth();
+d = date.getDate();
+
+if(document.querySelector(".date")) {
+  document.querySelector(".date").innerHTML = d + " " + monthNames[m] + " " + y;
+}
+
+if(document.querySelector(".short-date")) {
+  document.querySelector(".short-date").innerHTML = d + " " + monthNamesShort[m] + " " + y;
+}

--- a/app/filters.js
+++ b/app/filters.js
@@ -54,7 +54,7 @@ module.exports = function (env) {
       const STEP = i - ROW_COUNT
 
       nextSixMonths.push({
-        value: `${MONTH_NAMES[STEP].toLowerCase()}-${(ROW + 1)}`,
+        value: `${MONTH_NAMES[STEP].toLowerCase()}`,
         text: MONTH_NAMES[STEP]
       })
     }
@@ -69,8 +69,8 @@ module.exports = function (env) {
     if (typeof date !== 'undefined') {
       const rightNow = moment(new Date(date))
 
-      if (typeof method !== 'undefined' && 
-        typeof amount !== 'undefined' && 
+      if (typeof method !== 'undefined' &&
+        typeof amount !== 'undefined' &&
         typeof unit !== 'undefined') {
 
         const configObj = {
@@ -86,7 +86,7 @@ module.exports = function (env) {
           newDate = rightNow[configObj.method](configObj.amount, configObj.unit)
         }
       }
-      
+
       newDate = rightNow.format('DD MM YYYY')
     } else {
       const month = newDate.getMonth() + 1 < 10 ? `0${newDate.getMonth() + 1}` : newDate.getMonth()

--- a/app/routes.js
+++ b/app/routes.js
@@ -127,6 +127,91 @@ router.use(
 );
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
+//  ROUTING FOR VERSION 2.1                                                 //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+// This moves eligibility routing to eligibility directory
+router.use(
+  "/v2_1-citizen/1-eligibility/",
+  require("./views/v2_1-citizen/1-eligibility/_routes")
+);
+
+// This moves `abroad` routing to `abroad` directory
+router.use(
+  "/v2_1-citizen/2-claim-start/",
+  require("./views/v2_1-citizen/2-claim-start/_routes")
+);
+
+// This moves details routing to details directory
+router.use(
+  "/v2_1-citizen/3-details/",
+  require("./views/v2_1-citizen/3-details/_routes")
+);
+
+// Redirect to first question in details sequence
+router.get("/v2_1-citizen/3-details/", function (req, res) {
+  res.redirect("/v2_1-citizen/3-details/nino");
+});
+
+// This moves `other-benefits` routing to `other-benefits` directory
+router.use(
+  "/v2_1-citizen/4-other-benefits/",
+  require("./views/v2_1-citizen/4-other-benefits/_routes")
+);
+
+// This moves jury-service routing to jury-service directory
+router.use(
+  "/v2_1-citizen/5-jury-service/",
+  require("./views/v2_1-citizen/5-jury-service/_routes")
+);
+
+// This moves current-employment routing to current-employment directory
+router.use(
+  "/v2_1-citizen/6-current-employment/",
+  require("./views/v2_1-citizen/6-current-employment/_routes")
+);
+
+// This moves previous-employment routing to previous-employment directory
+router.use(
+  "/v2_1-citizen/7-previous-employment/",
+  require("./views/v2_1-citizen/7-previous-employment/_routes")
+);
+
+// This moves `abroad` routing to `abroad` directory
+router.use(
+  "/v2_1-citizen/8-abroad/",
+  require("./views/v2_1-citizen/8-abroad/_routes")
+);
+
+// This moves `pensions` routing to `pensions` directory
+router.use(
+  "/v2_1-citizen/9-pensions/",
+  require("./views/v2_1-citizen/9-pensions/_routes")
+);
+
+// This moves `education` routing to `education` directory
+router.use(
+  "/v2_1-citizen/10-education/",
+  require("./views/v2_1-citizen/10-education/_routes")
+);
+
+// This moves `availability` routing to `availability` directory
+router.use(
+  "/v2_1-citizen/11-availability/",
+  require("./views/v2_1-citizen/11-availability/_routes")
+);
+
+// This moves `error` routing to `error` directory
+router.use(
+  "/v2_1-citizen/error/",
+  require("./views/v2_1-citizen/error/_routes")
+);
+
+// {END OF ROUTING FOR VERSION 2.1} ///////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
 //  ROUTING FOR VERSION 2.0                                                 //
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////

--- a/app/views/includes/head-live-nobanner.html
+++ b/app/views/includes/head-live-nobanner.html
@@ -1,0 +1,20 @@
+<!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+
+{% for stylesheetUrl in extensionConfig.stylesheets %}
+  <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
+{% endfor %}
+
+
+<div class="govuk-width-container govuk-header__contents">
+<!-- <div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Help improve the New Style Jobseeker's Allowance online service. <a class="govuk-link" href="#">Volunteer to take part in research (opens in new tab)</a>
+    </span>
+  </p>
+</div> -->
+</div>

--- a/app/views/includes/head-live.html
+++ b/app/views/includes/head-live.html
@@ -1,0 +1,20 @@
+<!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+
+{% for stylesheetUrl in extensionConfig.stylesheets %}
+  <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
+{% endfor %}
+
+
+<!-- <div class="govuk-width-container govuk-header__contents">
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Prototype
+    </strong>
+    <span class="govuk-phase-banner__text">
+      Help improve the New Style Jobseeker's Allowance online service. <a class="govuk-link" href="#">Volunteer to take part in research (opens in new tab)</a>
+    </span>
+  </p>
+</div>
+</div> -->

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -6,101 +6,85 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">Prototypes</span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">Prototypes</span>
     Apply for New Style Jobseeker&rsquo;s Allowance
   </h1>
 
-  {# FOR THE PURPOSE OF THE GDS ASSESSMENT ONLY
-
-  <span class="govuk-tag">GDS assessment</span>
-  <h2 class="govuk-heading-l">Citizen journey</h2>
-  #<p>"Personal details" phone number conditionally revealed content</p>#
-  <ul class="govuk-list govuk-list--bullet">
-    <li>Variation of the citizen journey specifically for the GDS assessment</li>
-  </ul>
-  <a href="gds-citizen/1-eligibility/introduction" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
-    Start
-    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-    </svg>
-  </a>
-
-    <h2 class="govuk-heading-m">GDS assessment shortcut links</h2>
-
-      <div class="govuk-clearfix">
-      <div class="govuk-grid-column-one-half">
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a href="gds-citizen/1-eligibility/residence">Eligibility</a></li>
-          <li><a href="gds-citizen/2-claim-start/start-date">Claim start date</a></li>
-          <li><a href="gds-citizen/3-details">Personal details (NINO)</a></li>
-          <li><a href="gds-citizen/4-other-benefits">Other benefits</a></li>
-          <li><a href="gds-citizen/5-jury-service">Jury service</a></li>
-          <li><a href="gds-citizen/6-current-employment">Current employment</a></li>
-          <li><a href="gds-citizen/7-previous-employment">Previous employment</a></li>
-          <li><a href="gds-citizen/8-abroad">Worked or claimed benefit outside UK</a></li>
-        <ul>
-      </div>
-      <div class="govuk-grid-column-one-half">
-        <ul class="govuk-list govuk-list--bullet">
-          <li><a href="gds-citizen/9-pensions/9a-current-pension">Current pension</a></li>
-          <li><a href="gds-citizen/9-pensions/9b-deferred-pension">Deferred pension</a></li>
-          <li><a href="gds-citizen/9-pensions/9c-future-pension">Future pension</a></li>
-          <li><a href="gds-citizen/10-education">Education or training</a></li>
-          <li><a href="gds-citizen/check-answers">Check your answers</a></li>
-          <li><a href="gds-citizen/declaration">Declaration</a></li>
-          <li><a href="gds-citizen/confirmation">Confirmation</a></li>
-        </ul>
-      </div>
-      </div>
-
-  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-#}
-
-  <span class="govuk-tag">Latest version</span>
+  <span class="govuk-tag govuk-!-margin-bottom-2">Latest version</span>
   <h2 class="govuk-heading-l">Citizen journey</h2>
 
-  <p>Worked on by: Pete Leon, Poppy Davis and Camilla Insalaco</p>
+  <p>Worked on by: Pete Lonsdale, Andrew Donaghy and Will Clarke</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li>Aligned with the current live service [as of 28th September 2021]</li>
+    <li>Aligned with the current live service post ZDT release [as of 23rd August 2022]</li>
+    <li>Phase banner removed as part of live status</li>
+    <li>Check Your Answers page updated and now pulling dynamic content</li>
+    <li>Content changes on Eligible screen</li>
+    <li>Banking page
+      <ul>
+        <li>Content amends in detail component</li>
+        <li>Sort code changed from 3 to 1</li>
+      </ul>
+    </li>
+    <li>Current Employment
+      <ul>
+        <li>Content amends to titles</li>
+        <li>Employer name input width</li>
+      </ul>
+    </li>
+    <li>Start and End date content emds for Previous Employment</li>
+    <li>Pensions
+      <ul>
+        <li>Updated hint text</li>
+        <li>Updated section title</li>
+      </ul>
+    </li>
+    <li>Education
+      <ul>
+        <li>Update hours hint content</li>
+        <li>Updated Course Start and End dates labels</li>
+      </ul>
+    </li>
+    <li>Declaration content updated</li>
+    <li>Application complete screen updated</li>
   </ul>
 
   {{ govukButton({
-    text: "Version 2.0",
-    href: "v2_0-citizen/1-eligibility/introduction",
-    classes: "govuk-button--start"
+    text: "Start version 2.1",
+    href: "v2_1-citizen/1-eligibility/introduction",
+    isStartButton: true
   }) }}
 
   {{ govukDetails({
-    summaryText: "Version 2.0 shortcut links",
+    summaryText: "Version 2.1 shortcut links",
     html: '
       <div class="govuk-clearfix"><div class="govuk-grid-column-one-half">
         <ul class="govuk-list govuk-list--bullet">
-          <li><a href="v2_0-citizen/1-eligibility/introduction">Eligibility</a></li>
-          <li><a href="v2_0-citizen/2-claim-start/start-date">Claim start date</a></li>
-          <li><a href="v2_0-citizen/3-details">Personal details (NINO)</a></li>
-          <li><a href="v2_0-citizen/4-other-benefits">Other benefits</a></li>
-          <li><a href="v2_0-citizen/5-jury-service">Jury service</a></li>
-          <li><a href="v2_0-citizen/6-current-employment">Current employment</a></li>
-          <li><a href="v2_0-citizen/7-previous-employment">Previous employment</a></li>
-          <li><a href="v2_0-citizen/8-abroad">Worked or claimed benefit outside UK</a></li>
+          <li><a href="v2_1-citizen/1-eligibility/introduction">Eligibility</a></li>
+          <li><a href="v2_1-citizen/2-claim-start/start-date">Claim start date</a></li>
+          <li><a href="v2_1-citizen/3-details">Personal details (NINO)</a></li>
+          <li><a href="v2_1-citizen/4-other-benefits">Other benefits</a></li>
+          <li><a href="v2_1-citizen/5-jury-service">Jury service</a></li>
+          <li><a href="v2_1-citizen/6-current-employment">Current employment</a></li>
+          <li><a href="v2_1-citizen/7-previous-employment">Previous employment</a></li>
+          <li><a href="v2_1-citizen/8-abroad">Worked or claimed benefit outside UK</a></li>
         <ul>
       </div>
       <div class="govuk-grid-column-one-half">
         <ul class="govuk-list govuk-list--bullet">
-          <li><a href="v2_0-citizen/9-pensions/9a-current-pension">Current pension</a></li>
-          <li><a href="v2_0-citizen/9-pensions/9b-deferred-pension">Deferred pension</a></li>
-          <li><a href="v2_0-citizen/9-pensions/9c-future-pension">Future pension</a></li>
-          <li><a href="v2_0-citizen/10-education">Education or training</a></li>
-          <li><a href="v2_0-citizen/11-availability">Availability</a></li>
-          <li><a href="v2_0-citizen/check-answers">Check your answers</a></li>
-          <li><a href="v2_0-citizen/declaration">Declaration</a></li>
-          <li><a href="v2_0-citizen/confirmation">Confirmation</a></li>
+          <li><a href="v2_1-citizen/9-pensions/9a-current-pension">Current pension</a></li>
+          <li><a href="v2_1-citizen/9-pensions/9b-deferred-pension">Deferred pension</a></li>
+          <li><a href="v2_1-citizen/9-pensions/9c-future-pension">Future pension</a></li>
+          <li><a href="v2_1-citizen/10-education">Education or training</a></li>
+          <li><a href="v2_1-citizen/11-availability">Availability</a></li>
+          <li><a href="v2_1-citizen/check-answers">Check your answers</a></li>
+          <li><a href="v2_1-citizen/declaration">Declaration</a></li>
+          <li><a href="v2_1-citizen/confirmation">Confirmation</a></li>
         </ul>
       </div>'
     }) }}
+
 
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
@@ -251,6 +235,46 @@
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
   <h2 class="govuk-heading-l">Previous versions</h2>
+
+  <!-- VERSION 2.0 -->
+  <h3 class="govuk-heading-m">
+    <a href="v2_0-citizen/1-eligibility/introduction">Citizen journey &ndash; Version 2.0</a>
+  </h3>
+
+  <p>Worked on by: Pete Leon, Poppy Davis and Camilla Insalaco</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Aligned with the current live service [as of 28th September 2021]</li>
+  </ul>
+
+  {{ govukDetails({
+    summaryText: "Version 2.0 shortcut links",
+    html: '
+      <div class="govuk-clearfix"><div class="govuk-grid-column-one-half">
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="v2_0-citizen/1-eligibility/introduction">Eligibility</a></li>
+          <li><a href="v2_0-citizen/2-claim-start/start-date">Claim start date</a></li>
+          <li><a href="v2_0-citizen/3-details">Personal details (NINO)</a></li>
+          <li><a href="v2_0-citizen/4-other-benefits">Other benefits</a></li>
+          <li><a href="v2_0-citizen/5-jury-service">Jury service</a></li>
+          <li><a href="v2_0-citizen/6-current-employment">Current employment</a></li>
+          <li><a href="v2_0-citizen/7-previous-employment">Previous employment</a></li>
+          <li><a href="v2_0-citizen/8-abroad">Worked or claimed benefit outside UK</a></li>
+        <ul>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="v2_0-citizen/9-pensions/9a-current-pension">Current pension</a></li>
+          <li><a href="v2_0-citizen/9-pensions/9b-deferred-pension">Deferred pension</a></li>
+          <li><a href="v2_0-citizen/9-pensions/9c-future-pension">Future pension</a></li>
+          <li><a href="v2_0-citizen/10-education">Education or training</a></li>
+          <li><a href="v2_0-citizen/11-availability">Availability</a></li>
+          <li><a href="v2_0-citizen/check-answers">Check your answers</a></li>
+          <li><a href="v2_0-citizen/declaration">Declaration</a></li>
+          <li><a href="v2_0-citizen/confirmation">Confirmation</a></li>
+        </ul>
+      </div>'
+    }) }}
 
   <!-- VERSION 1.5 -->
   <h3 class="govuk-heading-m">

--- a/app/views/layout-live-complete.html
+++ b/app/views/layout-live-complete.html
@@ -1,0 +1,89 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+
+{# Custom macros #}
+{% from "macros/macros.njk"      import govukCurrencyInput,
+                                        grossPaymentAmountInput,
+                                        netPaymentAmountInput,
+                                        netAndGrossPaymentAmountInputs,
+                                        grossPensionAmountInput,
+                                        checkAnswersItem %}
+
+{% block head %}
+  {% include "includes/head-live-nobanner.html" %}
+{% endblock %}
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+  <!-- {% include "includes/cookie-banner.html" %} -->
+  {# Set serviceName in config.js. #}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+{% endblock %}
+
+
+<!-- {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %} -->
+
+
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "https://govuk-prototype-kit.herokuapp.com/",
+            text: "GOV.UK Prototype Kit " + releaseVersion
+          },
+          {
+            href: "/prototype-admin/clear-data",
+            text: "Clear data"
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+{% endblock %}

--- a/app/views/layout-live-nobanner.html
+++ b/app/views/layout-live-nobanner.html
@@ -1,0 +1,95 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+
+{# Custom macros #}
+{% from "macros/macros.njk"      import govukCurrencyInput,
+                                        grossPaymentAmountInput,
+                                        netPaymentAmountInput,
+                                        netAndGrossPaymentAmountInputs,
+                                        grossPensionAmountInput,
+                                        checkAnswersItem %}
+
+{% block head %}
+  {% include "includes/head-live-nobanner.html" %}
+{% endblock %}
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+  <!-- {% include "includes/cookie-banner.html" %} -->
+  {# Set serviceName in config.js. #}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+{% endblock %}
+
+
+<!-- {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %} -->
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:history.back()"
+  }) }}
+
+{% endblock %}
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "https://govuk-prototype-kit.herokuapp.com/",
+            text: "GOV.UK Prototype Kit " + releaseVersion
+          },
+          {
+            href: "/prototype-admin/clear-data",
+            text: "Clear data"
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+{% endblock %}

--- a/app/views/layout-live.html
+++ b/app/views/layout-live.html
@@ -1,0 +1,102 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+
+{# Custom macros #}
+{% from "macros/macros.njk"      import govukCurrencyInput,
+                                        grossPaymentAmountInput,
+                                        netPaymentAmountInput,
+                                        netAndGrossPaymentAmountInputs,
+                                        grossPensionAmountInput,
+                                        checkAnswersItem %}
+
+
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+  <!-- {% include "includes/cookie-banner.html" %} -->
+  {# Set serviceName in config.js. #}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "",
+      classes: "govuk-visually-hidden"
+    },
+    classes: "govuk-width-container",
+    html: 'Help improve the New Style Jobseeker&#39;s Allowance online service. <a class="govuk-link" href="#">Volunteer to take part in research (opens in new tab)</a>'
+  }) }}
+{% endblock %}
+
+{% block head %}
+  {% include "includes/head-live.html" %}
+{% endblock %}
+
+<!-- {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %} -->
+
+{% block beforeContent %}
+
+
+{% endblock %}
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "https://govuk-prototype-kit.herokuapp.com/",
+            text: "GOV.UK Prototype Kit " + releaseVersion
+          },
+          {
+            href: "/prototype-admin/clear-data",
+            text: "Clear data"
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/_routes.js
+++ b/app/views/v2_1-citizen/1-eligibility/_routes.js
@@ -1,0 +1,87 @@
+var express = require('express');
+var router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/1-eligibility';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = 'v2_1-citizen/2-claim-start';
+
+/*
+ * BRANCHING FOR ELIGIBILITY
+ *
+ * Current sequence is
+ *  1. Residence
+ *  2. Working
+ *    2.1 Working over 16 hours
+ *  3. Contributions
+ *  4. Eligible
+ * */
+
+/*
+ * THE INELIGIBILITY PAGES
+ *
+ * 1. ineligible-more-than-16-hours =
+ * The citizen is working over 16 hours per week
+ *
+ * 2. ineligibile-residency =
+ * The citizen doesn't live in England, Scotland or Wales
+ *
+ * 3. ineligible ==
+ * The citizen hasn't contributed enough NI
+ *
+ * Please note: the content of page number 3 should be copied to the other two
+ * */
+
+router.post('/residence', function (req, res) {
+  var answer = req.session.data['eligibilityResidence'];
+  if (answer === 'eligibility-residence-no') {
+    res.redirect(`${ABS_BASE_PATH}/ineligible-residency`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/working`);
+  }
+});
+
+// after residence we do working
+router.post('/working', function (req, res) {
+  var answer = req.session.data['eligibilityWorking'];
+  if (answer === 'eligibility-working-no') {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/working-over`);
+  }
+});
+
+// after working we do working over
+router.post('/working-over', function (req, res) {
+  var answer = req.session.data['eligibilityWorkingOver'];
+  if (answer === 'eligibility-working-over-no') {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/ineligible-more-than-16-hours`);
+  }
+});
+
+// after working over we do employed
+router.post('/employed', function (req, res) {
+  var answer = req.session.data['eligibilityEmployed'];
+  if (answer === 'eligibility-employed-yes') {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  } else if (answer === 'eligibility-employed-no') {
+    res.redirect(`${ABS_BASE_PATH}/ineligible`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  }
+});
+
+// after working over we do contributions
+router.post('/contributions', function (req, res) {
+  var answer = req.session.data['eligibilityContributions'];
+  if (answer === 'eligibility-contributions-yes') {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  } else if (answer === 'eligibility-contributions-no') {
+    res.redirect(`${ABS_BASE_PATH}/ineligible`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/eligible`);
+  }
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/1-eligibility/contributions.html
+++ b/app/views/v2_1-citizen/1-eligibility/contributions.html
@@ -1,0 +1,68 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Have you paid National Insurance over the last 3 years?
+      </h1>
+
+      <p>You may be eligible if you have paid Class 1 National Insurance contributions,
+      usually over the last 3 years. National Insurance credits can also count.</p>
+
+      <p>If you're not sure, you can still apply for New Style JSA. We'll check your
+      application to make sure you're eligible for this benefit.</p>
+
+
+      <form action="contributions" method="post">
+
+        <div class="govuk-form-group">
+
+            <fieldset class="govuk-fieldset">
+
+                {{ govukRadios({
+                    idPrefix: 'contributions',
+                    name: 'eligibilityContributions',
+                    items: [
+                        {
+                            value: "eligibility-contributions-yes",
+                            text: "Yes"
+                        },
+                        {
+                            value: "eligibility-contributions-no",
+                            text: "No"
+                        },
+                        {
+                            value: "eligibility-contributions-not-sure",
+                            text: "I'm not sure",
+                            conditional: {
+                              html: "<p>You can <a href='https://www.gov.uk/check-national-insurance-record'>check your National Insurance record online</a>.</p>"
+                            }
+                        }
+                    ]
+                })
+                }}
+
+            </fieldset>
+
+
+        </div>
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/earnings.html
+++ b/app/views/v2_1-citizen/1-eligibility/earnings.html
@@ -1,0 +1,52 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">Did you earn more than £120 per week?</h1>
+
+      <form action="earnings" method="post">
+
+        <div class="govuk-form-group">
+
+            <fieldset class="govuk-fieldset">
+
+                {{ govukRadios({
+                    idPrefix: 'earnings',
+                    name: 'eligibilityEarnings',
+                    items: [
+                        {
+                            value: "eligibility-earnings-yes",
+                            text: "Yes"
+                        },
+                        {
+                            value: "eligibility-earnings-no",
+                            text: "No"
+                        }
+                    ]
+                })
+                }}
+
+            </fieldset>
+
+
+        </div>
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+        <p>We'll check your application to make sure you are eligible for this benefit.</p>
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/eligible.html
+++ b/app/views/v2_1-citizen/1-eligibility/eligible.html
@@ -1,0 +1,37 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">You may be eligible for New Style Jobseeker's Allowance</h1>
+<p>Based on your answers, you may be able to get New Style Jobseeker's Allowance</p>
+      <p class="govuk-body">To apply, you'll need your:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>National Insurance number</li>
+        <li>bank or building society account details (or those of a family member or trusted friend)</li>
+        <li>employment details for the last 6 months, including employer contact details and dates you worked with them</li>
+        <li>private pension or annuity statement if you get, or could get, payments from one</li>
+      </ul>
+
+      <div class="govuk-inset-text">It usually takes 20 minutes to complete the form. You cannot save your answers and come back to the form later. But you’ll get a chance to check and update your answers before you send it.</div>
+      <p>
+                The Department for Work and Pensions will treat your personal information carefully. We may use it for any of our purposes. To learn about your information rights and how we use information, see our
+                <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-work-pensions/about/personal-information-charter">personal information charter</a>.
+            </p>
+
+      {{ govukButton({
+            text: "Start now",
+            href: "../2-claim-start/start-date"
+        }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/employed.html
+++ b/app/views/v2_1-citizen/1-eligibility/employed.html
@@ -1,0 +1,50 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">Have you been employed in the past 3 years?</h1>
+
+      <form action="employed" method="post">
+
+        <div class="govuk-form-group">
+
+            <fieldset class="govuk-fieldset">
+
+                {{ govukRadios({
+                    idPrefix: 'employed',
+                    name: 'eligibilityEmployed',
+                    items: [
+                        {
+                            value: "eligibility-employed-yes",
+                            text: "Yes"
+                        },
+                        {
+                            value: "eligibility-employed-no",
+                            text: "No"
+                        }
+                    ]
+                })
+                }}
+
+            </fieldset>
+
+
+        </div>
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/includes/still-apply.html
+++ b/app/views/v2_1-citizen/1-eligibility/includes/still-apply.html
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-m">Do you still want to apply?</h2>
+<p>You can continue to apply for New Style Jobseeker's Allowance if you still think you’re eligible for it.</p>

--- a/app/views/v2_1-citizen/1-eligibility/ineligible-more-than-16-hours.html
+++ b/app/views/v2_1-citizen/1-eligibility/ineligible-more-than-16-hours.html
@@ -1,0 +1,29 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <h1 class="govuk-heading-l">You're not eligible for New Style Jobseeker's Allowance</h1>
+
+            <p>Based on your answer, you cannot get New Style Jobseeker's Allowance. To get it you must not be working, or be working less than 16 hours a week on average.</p>
+
+            <p class="govuk-!-margin-top-6">If you are not sure which benefit to apply for you can check online.</p>
+            {{ govukButton({
+                text: "Find other benefits",
+                href: "https://www.gov.uk/benefits-calculators"
+            }) }}
+
+            {% include "v2_1-citizen/1-eligibility/includes/still-apply.html" %}
+            <p><a href="/v2_1-citizen/2-claim-start/start-date" class="js-still-apply">Continue to apply</a>
+
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/ineligible-residency.html
+++ b/app/views/v2_1-citizen/1-eligibility/ineligible-residency.html
@@ -1,0 +1,32 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <h1 class="govuk-heading-l">You're not eligible for New Style Jobseeker's Allowance</h1>
+
+            <section>
+                <p class="govuk-body">Based on your answer, you cannot get New Style Jobseeker's Allowance. To get it you must live in England, Scotland or Wales.</p>
+
+            </section>
+
+            <p class="govuk-!-margin-top-6">If you are not sure which benefit to apply for you can check online.</p>
+            {{ govukButton({
+                text: "Find other benefits",
+                href: "https://www.gov.uk/benefits-calculators"
+            }) }}
+
+            {% include "v2_1-citizen/1-eligibility/includes/still-apply.html" %}
+            <p><a href="working" class="js-still-apply">Continue to apply</a>
+
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/ineligible.html
+++ b/app/views/v2_1-citizen/1-eligibility/ineligible.html
@@ -1,0 +1,32 @@
+
+{{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <h1 class="govuk-heading-l">Based on your answers, you may not be eligible for New Style Jobseeker's Allowance (JSA)</h1>
+
+            <section>
+                <p class="govuk-body">This is because you must have worked as an employee and paid Class 1 National Insurance contributions, usually in the last 2 to 3 years, to get New Style JSA.</p>
+
+            </section>
+
+            <p class="govuk-!-margin-top-6">If you are not sure which benefit to apply for you can check online.</p>
+            {{ govukButton({
+                text: "Find other benefits",
+                href: "https://www.gov.uk/benefits-calculators"
+            }) }}
+
+            {% include "v1_5-citizen/1-eligibility/includes/still-apply.html" %}
+            <p><a href="../2-claim-start/start-date" class="js-still-apply">Continue to apply</a>
+
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/introduction.html
+++ b/app/views/v2_1-citizen/1-eligibility/introduction.html
@@ -1,0 +1,29 @@
+
+{% extends "layout-live.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <h1 class="govuk-!-margin-top-0 govuk-fieldset__legend--l">Find out if you may be eligible for New Style Jobseeker's Allowance</h1>
+
+        <p>Answer these questions to find out if you may be eligible for New Style Jobseeker's Allowance</p>
+
+        {{ govukButton({
+            text: "Continue",
+            href: "residence"
+        }) }}
+
+
+        <p>The online service is also available in <a href='#'>Welsh (Cymraeg)</a>.</p>
+
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/residence.html
+++ b/app/views/v2_1-citizen/1-eligibility/residence.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Do you live in England, Wales or Scotland?
+      </h1>
+
+      <form action="residence" method="post">
+
+        {{ govukRadios({
+            classes: "govuk-radios--inline",
+            idPrefix: 'residence',
+            name: 'eligibilityResidence',
+            items: [
+                {
+                    value: "eligibility-residence-yes",
+                    text: "Yes"
+                },
+                {
+                    value: "eligibility-residence-no",
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/working-over.html
+++ b/app/views/v2_1-citizen/1-eligibility/working-over.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        How many hours a week do you normally work?
+      </h1>
+
+      <form action="working-over" method="post">
+
+        {{ govukRadios({
+            classes: "govuk-radios",
+            idPrefix: 'working-over-form',
+            name: 'eligibilityWorkingOver',
+            items: [
+                {
+                  value: "eligibility-working-over-yes",
+                  text: "16 hours or more"
+              },
+              {
+                  value: "eligibility-working-over-no",
+                  text: "Less than 16 hours"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/1-eligibility/working.html
+++ b/app/views/v2_1-citizen/1-eligibility/working.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Are you in paid work?
+      </h1>
+
+      <form action="working" method="post">
+
+        {{ govukRadios({
+            classes: "govuk-radios--inline",
+            idPrefix: 'working',
+            name: 'eligibilityWorking',
+            items: [
+                {
+                  value: "eligibility-working-yes",
+                  text: "Yes"
+              },
+              {
+                  value: "eligibility-working-no",
+                  text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/10-education/_routes.js
+++ b/app/views/v2_1-citizen/10-education/_routes.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/10-education';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/check-answers';
+
+// Redirect /education to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.eduHaveYou;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      res.redirect(`${ABS_BASE_PATH}/course-name`);
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/course-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/institution-name`);
+});
+
+router.post('/institution-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/course-hours`);
+});
+
+router.post('/course-hours', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/course-duration`);
+});
+
+router.post('/course-duration', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/10-education/course-duration.html
+++ b/app/views/v2_1-citizen/10-education/course-duration.html
@@ -1,0 +1,101 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Education and training</span>
+        When did you attend this course?
+      </h1>
+
+      <form action="course-duration" method="post">
+
+        {{ govukDateInput({
+          id: 'edu-when-education-start',
+          name: 'eduWhenEducationStart',
+          fieldset: {
+            legend: {
+                text: 'Course start date',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+              text: "For example, 1 9 2018"
+          },
+          items: [
+            {
+              name: 'eduStartDay',
+              value: data['eduStartDay'],
+              label: "Day",
+              classes: 'govuk-input--width-2'
+            },
+            {
+              name: 'eduStartMonth',
+              value: data['eduStartMonth'],
+              label: "Month",
+              classes: 'govuk-input--width-2'
+            },
+            {
+              name: 'eduStartYear',
+              value: data['eduStartYear'],
+              label: "Year",
+              classes: 'govuk-input--width-4'
+            }
+          ]
+          })
+        }}
+
+        {{ govukDateInput({
+          id: 'edu-when-education-finish',
+          name: 'eduWhenEducationFinish',
+          fieldset: {
+            legend: {
+                text: 'Course end date',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+
+            html: 'For example, 24 9 2019<br>This needs to be the official end date of the whole course'
+          },
+          items: [
+            {
+              name: 'eduFinishDay',
+              value: data['eduFinishDay'],
+              label: "Day",
+              classes: 'govuk-input--width-2'
+            },
+            {
+              name: 'eduFinishMonth',
+              value: data['eduFinishMonth'],
+              label: "Month",
+              classes: 'govuk-input--width-2'
+            },
+            {
+              name: 'eduFinishYear',
+              value: data['eduFinishYear'],
+              label: "Year",
+              classes: 'govuk-input--width-4'
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/10-education/course-hours.html
+++ b/app/views/v2_1-citizen/10-education/course-hours.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Education and training</span>
+        How many hours a week did you spend on the course?
+      </h1>
+
+      <form action="course-hours" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        <p class="govuk-hint">This includes supervised study, any time in class and any compulsory work set by your course director or tutor to be completed out of class.</p>
+
+        <div class="govuk-form-group govuk-short-input">
+            <label class="govuk-label govuk-visually-hidden" for="eduCourseHours">Hours per week</label>
+            <input value="{{ data['eduCourseHours'] }}" class="govuk-input govuk-input--width-3 govuk-!-margin-right-2" id="edu-course-hours" name="eduCourseHours">
+            <span class="govuk-body">hours</span>
+        </div>
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/10-education/course-name.html
+++ b/app/views/v2_1-citizen/10-education/course-name.html
@@ -1,0 +1,39 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Education and training</span>
+        What was the name of the course?
+      </h1>
+
+      <form action="course-name" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          classes: "govuk-!-width-two-thirds",
+          id: "edu-course-name",
+          name: "eduCourseName",
+          value: data['eduCourseName']
+        }) }}
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/10-education/guard.html
+++ b/app/views/v2_1-citizen/10-education/guard.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Education and training</span>
+        Have you been in education or training in the last 4 years?
+      </h1>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          idPrefix: "edu-have-you",
+          name: "eduHaveYou",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "Yes",
+            checked: checked("eduHaveYou", "Yes"),
+            text: "Yes"
+          }, {
+            value: "No",
+            checked: checked("eduHaveYou", "No"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/10-education/institution-name.html
+++ b/app/views/v2_1-citizen/10-education/institution-name.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Education and training</span>
+        What was the name of the education or training provider?
+      </h1>
+
+      <form action="course-hours">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Institution name",
+            classes: "govuk-visually-hidden"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "edu-institution-name",
+          name: "eduInstitutionName",
+          value: data['eduInstitutionName'],
+          hint: {
+            text: "For example, The Open University"
+        }
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/11-availability/_routes.js
+++ b/app/views/v2_1-citizen/11-availability/_routes.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/11-availability';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/check-answers';
+
+// Redirect /education to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.availability;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'availability-yes') {
+      res.redirect(`${ABS_BASE_PATH}/availability`);
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/availability', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/11-availability/availability.html
+++ b/app/views/v2_1-citizen/11-availability/availability.html
@@ -1,0 +1,139 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Availability for jobcentre interview</span>
+        Tell us the days and times when you cannot attend a jobcentre interview
+      </h1>
+
+      <p>Tick the days and times when you're not free to attend.</p>
+
+      <form action="availability" method="post">
+
+        <div class="govuk-form-group govuk-!-margin-top-6">
+          <fieldset class="govuk-fieldset">
+
+            {{ govukCheckboxes({
+              idPrefix: "fri-7th",
+              name: "fri-7th",
+              fieldset: {
+                legend: {
+                  text: "Friday 7 December",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [{
+                value: "morning",
+                text: "Morning"
+              }, {
+                value: "afternoon",
+                text: "Afternoon"
+              }]
+            }) }}
+
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+            {{ govukCheckboxes({
+              idPrefix: "mon-10th",
+              name: "mon-10th",
+              fieldset: {
+                legend: {
+                  text: "Monday 10 December",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [{
+                value: "morning",
+                text: "Morning"
+              }, {
+                value: "afternoon",
+                text: "Afternoon"
+              }]
+            }) }}
+
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+            {{ govukCheckboxes({
+              idPrefix: "tue-11th",
+              name: "tue-11th",
+              fieldset: {
+                legend: {
+                  text: "Tuesday 11 December",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [{
+                value: "morning",
+                text: "Morning"
+              }, {
+                value: "afternoon",
+                text: "Afternoon"
+              }]
+            }) }}
+
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+            {{ govukCheckboxes({
+              idPrefix: "wed-12th",
+              name: "wed-12th",
+              fieldset: {
+                legend: {
+                  text: "Wednesday 12 December",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [{
+                value: "morning",
+                text: "Morning"
+              }, {
+                value: "afternoon",
+                text: "Afternoon"
+              }]
+            }) }}
+
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+            {{ govukCheckboxes({
+              idPrefix: "thu-13th",
+              name: "thu-13th",
+              fieldset: {
+                legend: {
+                  text: "Thursday 13 December",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [{
+                value: "morning",
+                text: "Morning"
+              }, {
+                value: "afternoon",
+                text: "Afternoon"
+              }]
+            }) }}
+
+          </fieldset>
+        </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/11-availability/guard.html
+++ b/app/views/v2_1-citizen/11-availability/guard.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Availability for jobcentre interview</span>
+        Are there any days and times that you cannot attend a jobcentre interview in the next 5 days?
+      </h1>
+
+      <form action="guard" method="post">
+        {{ govukRadios({
+          idPrefix: "availability",
+          name: "availability",
+          classes: "govuk-radios--inline",
+          hint: {
+            text: "You have to attend a jobcentre interview to complete your application for New Style Jobseeker’s Allowance."
+          },
+          items: [{
+            value: "availability-yes",
+            text: "Yes"
+          }, {
+            value: "availability-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/_routes.js
+++ b/app/views/v2_1-citizen/2-claim-start/_routes.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/2-claim-start';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/3-details';
+
+// Do you want to change the start date?
+router.post('/start-date', function (req, res) {
+  const answer = req.body.claimstart;
+
+  if (answer === 'yes') {
+    // Yes, I want my claim to start from today {current-date}
+    res.redirect(`${NEXT_PATH}/nino`);
+  } else {
+    // No, I want my claim to start from an earlier date
+    res.redirect(`${ABS_BASE_PATH}/change-date`);
+  };
+});
+
+// When do you want your claim to start?
+router.post('/change-date', function (req, res) {
+  res.redirect(`${NEXT_PATH}`);
+});
+
+// Did you ask for advice?
+// router.post('/asked-for-advice', function (req, res) {
+//   res.redirect(`${NEXT_PATH}`);
+// });
+
+module.exports = router;

--- a/app/views/v2_1-citizen/2-claim-start/any-paid-work.html
+++ b/app/views/v2_1-citizen/2-claim-start/any-paid-work.html
@@ -1,0 +1,46 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Have you been in paid work since 22 July 2020?
+      </h1>
+      <form action="unable-to-work" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-paid-work",
+          name: "cePaidWork",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("cePaidWork", "yes")
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: checked("cePaidWork", "no")
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/asked-for-advice.html
+++ b/app/views/v2_1-citizen/2-claim-start/asked-for-advice.html
@@ -1,0 +1,66 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Have you asked for advice about applying for New Style Jobseeker&rsquo;s Allowance since 22 July 2020?
+      </h1>
+      <p>This could be spoken or written advice from a government department, a legal or professional adviser or from an advice agency, such as Citizens Advice.</p>
+      <form action="/v2_1-citizen/3-details/nino" method="post">
+
+        {% set askedAdviceYes %}
+
+        {{ govukCharacterCount({
+            name: "more-information",
+            id: "more-information",
+            rows: 5,
+            maxlength: 600,
+            value: data['more-information'],
+            label: {
+              text: "Tell us who you contacted, when you contacted them and what information you were given."
+            }
+          }) }}
+
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: 'asked-for-advice',
+          name: 'asked-for-advice',
+          fieldset: {
+            legend: {
+              text: "",
+              isPageHeading: false
+            }
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("asked-for-advice", "yes"),
+            conditional: {
+              html: askedAdviceYes
+            }
+          }, {
+            value: "no",
+            checked: checked("asked-for-advice", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/available-for-work.html
+++ b/app/views/v2_1-citizen/2-claim-start/available-for-work.html
@@ -1,0 +1,46 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Were you available for work from 22 July 2020?
+      </h1>
+      <form action="searching-for-work" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-currently-working",
+          name: "ceCurrentlyWorking",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("ceCurrentlyWorking", "yes")
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: checked("ceCurrentlyWorking", "no")
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/been-on-holiday.html
+++ b/app/views/v2_1-citizen/2-claim-start/been-on-holiday.html
@@ -1,0 +1,125 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Have you travelled outside of England, Wales or Scotland since 22 July 2020?
+      </h1>
+      <p class="govuk-body">
+        Select yes if you have travelled outside of Great Britain (England, Wales or Scotland) for any reason.
+      </p>
+      <form action="full-time-education" method="post">
+
+        {% set holidayHtml %}
+        {{ govukDateInput({
+            id: 'holiday-start',
+            name: 'holidayStart',
+            fieldset: {
+              legend: {
+                text: 'Enter the date you left',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+              }
+            },
+            hint: {
+              html: 'For example, ' + todaysDate.original | moment('subtract', 12, 'months')
+            },
+            items: [
+              {
+                name: 'holidayStartDay',
+                value: data['holidayStartDay'],
+                classes: 'govuk-input--width-2',
+                label: 'Day'
+              },
+              {
+                name: 'holidayStartMonth',
+                value: data['holidayStartMonth'],
+                classes: 'govuk-input--width-2',
+                label: 'Month'
+              },
+              {
+                name: 'holidayStartYear',
+                value: data['holidayStartYear'],
+                classes: 'govuk-input--width-4',
+                label: 'Year'
+              }
+            ]
+            })
+          }}
+
+        {{ govukDateInput({
+            id: 'holiday-finish',
+            name: 'holidayFinish',
+            fieldset: {
+              legend: {
+                text: 'Enter the date you returned',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+              }
+            },
+            hint: {
+              html: 'For example, ' + todaysDate.original | moment
+            },
+            items: [
+              {
+                name: 'holidayFinishDay',
+                value: data['holidayFinishDay'],
+                classes: 'govuk-input--width-2',
+                label: 'Day'
+              },
+              {
+                name: 'holidayFinishMonth',
+                value: data['holidayFinishMonth'],
+                classes: 'govuk-input--width-2',
+                label: 'Month'
+              },
+              {
+                name: 'holidayFinishYear',
+                value: data['holidayFinishYear'],
+                classes: 'govuk-input--width-4',
+                label: 'Year'
+              }
+            ]
+            })
+          }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: "been-on-holiday",
+          name: "beenOnHoliday",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("beenOnHoliday", "yes"),
+            conditional: {
+              html: holidayHtml
+            }
+          },
+          {
+            value: "no",
+            checked: checked("beenOnHoliday", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/change-date.html
+++ b/app/views/v2_1-citizen/2-claim-start/change-date.html
@@ -1,0 +1,65 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        When do you want your application to start?
+      </h1>
+
+      <p>You can ask for your claim to be backdated by up to 3 months. You'll need to tell us why you want to backdate your claim later in the application.</p>
+
+      <form action="available-for-work" method="post">
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="claim-start-hint">
+            <div id="claim-start-hint" class="govuk-hint">
+              For example, 01 08 2022
+            </div>
+            <div class="govuk-date-input" id="claim-start">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="claim-start-day">
+                    Day
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="claim-start-day" name="claim-start-day" type="text" inputmode="numeric" value="{{ data['claim-start-day'] }}">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="claim-start-month">
+                    Month
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="claim-start-month" name="claim-start-month" type="text" inputmode="numeric" value="{{ data['claim-start-month'] }}">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="claim-start-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="claim-start-year" name="claim-start-year" type="text" inputmode="numeric" value="{{ data['claim-start-year'] }}">
+                </div>
+              </div>
+            </div>
+
+          </fieldset>
+        </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/full-time-education.html
+++ b/app/views/v2_1-citizen/2-claim-start/full-time-education.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Have you been in full-time education since 22 July 2020?
+      </h1>
+
+      <form action="asked-for-advice" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "full-time-education",
+          name: "fulltimeEducation",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("fulltimeEducation", "yes")
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: checked("fulltimeEducation", "no")
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/searching-for-work.html
+++ b/app/views/v2_1-citizen/2-claim-start/searching-for-work.html
@@ -1,0 +1,46 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Were you searching for work from 22 July 2020?
+      </h1>
+      <form action="why-have-you-not-claimed" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-currently-searching",
+          name: "ceCurrentlySearching",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("ceCurrentlySearching", "yes")
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: checked("ceCurrentlySearching", "no")
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/start-date.html
+++ b/app/views/v2_1-citizen/2-claim-start/start-date.html
@@ -1,0 +1,102 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{#
+  Backdating page flow:
+
+    index [Do you want your claim to start today?]
+
+    Answer "NO":
+      change-date [When do you want your claim to start?]
+      why-have-you-not-claimed [Tell us why you did not claim NSJSA before today]
+      any-paid-work [Have you been in paid or voluntary work since <date>?]
+      unable-to-work [Have you been ill and unable to work since <date>?]
+      been-on-holiday [Have you been on holiday since <date>?]
+      full-time-education [Have you been in full-time education since <date>?]
+      asked-for-advice [Have you asked for advice about claiming NSJSA since <date>?]
+
+    {Rejoin flow as per answering "YES"}
+
+    Answer "YES":
+      nino [What is your National Insurance number?]
+#}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Do you want your application to start today?
+      </h1>
+
+      {{ govukInsetText({
+        text: "We cannot backdate your claim if you did not know you could apply for New Style Jobseeker's Allowance (JSA) before today or thought you would get a job.
+"
+      }) }}
+
+      <p>In certain circumstances, your New Style JSA claim can be backdated by up to 3 months. If your claim is eligible for backdating, you can get up to 3 months of New Style JSA in your first payment.</p>
+
+<p>We can only consider backdating your claim in certain circumstances, for example if:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the Department for Work and Pensions, a legal or professional adviser or an advice agency such as Citizens Advice told you that you could not get New Style JSA</li>
+    <li>your partner, parent, child, brother or sister died</li>
+    <li>you were caring for someone with an illness or disability</li>
+  </ul>
+
+  <p>If you want us to backdate your claim, you'll need to tell us:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the date you want your claim to start</li>
+      <li>why you did not apply before today</li>
+    </ul>
+
+    <p>If your claim is eligible for backdating, you'll get New Style JSA for up to 6 months from the date you asked to backdate your claim to.</p>
+      <form action="start-date" method="post">
+
+        {% call govukFieldset({}) %}
+
+        {{ govukWarningText({
+          text: "You cannot change the start date later in the application.",
+          iconFallbackText: "Warning"
+        }) }}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "change-claim-start",
+          name: "claimstart",
+          fieldset: {
+            legend: {
+
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              html: "Yes, I want my application to start from today <strong class='date'></strong>"
+            },
+            {
+              value: "no",
+              html: "No, I want my application to start from an earlier date"
+            }
+          ]
+        }) }}
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/unable-to-work.html
+++ b/app/views/v2_1-citizen/2-claim-start/unable-to-work.html
@@ -1,0 +1,126 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Have you been unable to work because of illness since 22 July 2020?
+      </h1>
+      <p class="govuk-body">
+        You will need to tell us the dates you were unable to work.
+      </p>
+
+      <form action="been-on-holiday" method="post">
+
+        {% set illnessHtml %}
+        {{ govukDateInput({
+            id: 'illness-start',
+            name: 'illnessStart',
+            fieldset: {
+              legend: {
+                text: 'Enter the date the illness started',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+              }
+            },
+            hint: {
+              html: 'For example, ' + todaysDate.original | moment('subtract', 12, 'months')
+            },
+            items: [
+              {
+                name: 'illnessStartDay',
+                value: data['illnessStartDay'],
+                classes: 'govuk-input--width-2',
+                label: 'Day'
+              },
+              {
+                name: 'illnessStartMonth',
+                value: data['illnessStartMonth'],
+                classes: 'govuk-input--width-2',
+                label: 'Month'
+              },
+              {
+                name: 'illnessStartYear',
+                value: data['illnessStartYear'],
+                classes: 'govuk-input--width-4',
+                label: 'Year'
+              }
+            ]
+            })
+          }}
+
+        {{ govukDateInput({
+            id: 'illness-finish',
+            name: 'illnessFinish',
+            fieldset: {
+              legend: {
+                text: 'Enter the date the illness ended',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+              }
+            },
+            hint: {
+              html: 'For example, ' + todaysDate.original | moment
+            },
+            items: [
+              {
+                name: 'illnessFinishDay',
+                value: data['illnessFinishDay'],
+                classes: 'govuk-input--width-2',
+                label: 'Day'
+              },
+              {
+                name: 'illnessFinishMonth',
+                value: data['illnessFinishMonth'],
+                classes: 'govuk-input--width-2',
+                label: 'Month'
+              },
+              {
+                name: 'illnessFinishYear',
+                value: data['illnessFinishYear'],
+                classes: 'govuk-input--width-4',
+                label: 'Year'
+              }
+            ]
+            })
+          }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: "unable-to-work",
+          name: "unableToWork",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("unableToWork", "yes"),
+            conditional: {
+              html: illnessHtml
+            }
+          },
+          {
+            value: "no",
+            checked: checked("unableToWork", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/2-claim-start/why-have-you-not-claimed.html
+++ b/app/views/v2_1-citizen/2-claim-start/why-have-you-not-claimed.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Application start date</span>
+        Tell us why you did not apply for New Style Jobseeker’s Allowance before today
+      </h1>
+
+      <form action="any-paid-work" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukCharacterCount({
+          name: "why-did-you-not-claim",
+          id: "why-did-you-not-claim",
+          rows: 5,
+          maxlength: 600,
+          value: data['why-did-you-not-claim'],
+          label: {
+            text: "Give as much information as you can about why you did not apply sooner. For example, if you thought you could not apply you must tell us why you thought this."
+          }
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/_routes.js
+++ b/app/views/v2_1-citizen/3-details/_routes.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/3-details';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/4-other-benefits';
+
+router.post('/add-different-postal-address', function (req, res) {
+  const answer = req.body.detailsAddDifferentPostalAddress;
+
+  if (answer === 'No') {
+    res.redirect(`${ABS_BASE_PATH}/contact-phone`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/address-postal-address`);
+  }
+});
+
+// Validate DOB against year
+router.post('/address', function (req, res) {
+  var dobYear = parseInt(req.session.data['dobYear']);
+  var currentYear = new Date().getFullYear();
+
+  if (currentYear - dobYear < 16) {
+    res.redirect('/v2_1-citizen/3-details/dob?under16');
+  } else if (currentYear - dobYear > 64) {
+    res.redirect('/v2_1-citizen/3-details/dob?over64');
+  } else if (currentYear - dobYear === 16) {
+    res.redirect('/v2_1-citizen/3-details/under18');
+  } else if (currentYear - dobYear === 17) {
+    res.redirect('/v2_1-citizen/3-details/under18');
+  } else {
+    res.redirect('/v2_1-citizen/3-details/address');
+  }
+});
+
+router.post('/contact-phone', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/contact-do-you-have-an-email`);
+});
+
+router.post('/contact-do-you-have-an-email', function (req, res) {
+  const answer = req.body.contactDoYouHaveAnEmail;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      res.redirect(`${ABS_BASE_PATH}/contact-email`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/bank-account`);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/contact-do-you-have-an-email`);
+  }
+});
+
+router.post('/contact-email', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/bank-account`);
+});
+
+router.post('/bank-account', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/3-details/about-you.html
+++ b/app/views/v2_1-citizen/3-details/about-you.html
@@ -1,0 +1,99 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        About you
+      </h1>
+
+      <form action="dob" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+            {{ govukSelect({
+                id: "title",
+                name: "title",
+                label: {
+                    text: "Title"
+                },
+                classes: "govuk-input--width-10",
+                items: [
+                    {
+                        value: "Not selected",
+                        text: "Select an option",
+                        selected: true
+                    },
+                    {
+                        value: "Mr",
+                        text: "Mr",
+                        selected: checked("title", "Mr")
+                    },
+                    {
+                        value: "Mrs",
+                        text: "Mrs",
+                        selected: checked("title", "Mrs")
+                    },
+                    {
+                        value: "Miss",
+                        text: "Miss",
+                        selected: checked("title", "Miss")
+                    },
+                    {
+                        value: "Ms",
+                        text: "Ms",
+                        selected: checked("title", "Ms")
+                    },
+                    {
+                        value: "Dr",
+                        text: "Dr",
+                        selected: checked("title", "Dr")
+                    },
+                    {
+                        value: "Rev",
+                        text: "Rev",
+                        selected: checked("title", "Rev")
+                    }
+                ]
+            }) }}
+
+            {{ govukInput({
+                label: {
+                    text: "First name"
+                },
+                classes: "govuk-input--width-20",
+                id: "first-name",
+                name: "first-name",
+                value: data['first-name']
+            }) }}
+
+            {{ govukInput({
+                label: {
+                    text: "Last name"
+                },
+                classes: "govuk-input--width-20",
+                id: "last-name",
+                name: "last-name",
+                value: data['last-name']
+            }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/address-is-it-postal.html
+++ b/app/views/v2_1-citizen/3-details/address-is-it-postal.html
@@ -1,0 +1,45 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        Do you want to add a different address for your post?
+      </h1>
+
+      <form action="add-different-postal-address" method="post">
+
+        {{ govukRadios({
+            idPrefix: 'details-add-different-postal-address',
+            name: 'detailsAddDifferentPostalAddress',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "yes",
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/address-postal-address.html
+++ b/app/views/v2_1-citizen/3-details/address-postal-address.html
@@ -1,0 +1,69 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        What is your postal address?
+      </h1>
+
+      <form action="contact-phone">
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+          },
+          id: "postal-address-line-1",
+          name: "postal-address-line-1",
+          value: data["postal-address-line-1"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+          },
+          id: "postal-address-line-2",
+          name: "postal-address-line-2",
+          value: data["postal-address-line-2"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+          text: "Town or city"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "postal-address-town",
+          name: "postal-address-town",
+          value: data["postal-address-town"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+          text: "Postcode"
+          },
+          classes: "govuk-input--width-10",
+          id: "postal-address-postcode",
+          name: "postal-address-postcode",
+          value: data["postal-address-postcode"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/address.html
+++ b/app/views/v2_1-citizen/3-details/address.html
@@ -1,0 +1,92 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        What is your address?
+      </h1>
+
+      <form action="address-is-it-postal" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+            label: {
+            html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+            },
+            id: "address-line-1",
+            name: "address-line-1",
+            value: data['address-line-1']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+            },
+            id: "address-line-2",
+            name: "address-line-2",
+            value: data['address-line-2']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            text: 'Town or city'
+            },
+            classes: 'govuk-!-width-two-thirds',
+            id: "address-town",
+            name: "address-town",
+            value: data['address-town']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            text: 'Postcode'
+            },
+            classes: 'govuk-input--width-10',
+            id: "address-postcode",
+            name: "address-postcode",
+            value: data['address-postcode']
+        }) }}
+
+      {% endcall %}
+
+      <!-- save the date value from the last screen  -->
+      {{ govukInput({
+        type: "hidden",
+        id:  "dob-day",
+        name:  "dob-day",
+        value: data["day"]
+      })  }}
+
+      {{ govukInput({
+          type: "hidden",
+          id:  "dob-month",
+          name:  "dob-month",
+          value: data["month"]
+        })  }}
+      {{ govukInput({
+          type: "hidden",
+          id:  "dob-year",
+          name:  "dob-year",
+          value: data["year"]
+        })  }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/bank-account.html
+++ b/app/views/v2_1-citizen/3-details/bank-account.html
@@ -1,0 +1,94 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        Your bank details
+      </h1>
+
+      <form action="/v2_1-citizen/4-other-benefits/guard" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        <p>This is the account your New Style Jobseeker&rsquo;s Allowance will be paid into.</p>
+
+        {{ govukDetails({
+            summaryText: "What to do if you don't have a bank account",
+            html: '<p>We can use an account of a trusted family member or friend if you don&rsquo;t have a bank account.</p>
+            <p><a href="/v2_1-citizen/4-other-benefits/guard">Continue without providing bank details</a></p>'
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "Name of account holder"
+            },
+            id: "pay-account-holder",
+            name: "pay-account-holder",
+            value: data['pay-account-holder'],
+            classes: "govuk-input--width-20"
+        }) }}
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="sort-code">
+            Sort code
+          </label>
+          <!-- <div id="sort-code-hint" class="govuk-hint">
+            Must be 6 digits long
+          </div> -->
+          <input class="govuk-input govuk-input--width-5" id="sort-code" name="sort-code" type="text" spellcheck="false" aria-describedby="sort-code-hint" inputmode="numeric" value="{{ data['sort-code'] }}">
+        </div>
+
+
+        {{ govukInput({
+            label: {
+                text: "Account number"
+            },
+            id: "pay-account-number",
+            name: "pay-account-number",
+            value: data['pay-account-number'],
+            classes: "govuk-input--width-20",
+            type: "number",
+            attributes: {
+                "maxlength": "18"
+            }
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: "Building society roll or reference number (optional)"
+            },
+            id: "pay-reference-number",
+            name: "pay-reference-number",
+            value: data['pay-reference-number'],
+            classes: "govuk-input--width-20",
+            type: "number",
+            hint: {
+                text: "If your building society uses a roll or reference number, you will find it on your passbook."
+            },
+            attributes: {
+                "maxlength": "18"
+            }
+        }) }}
+
+
+        {% endcall %}
+
+          {{ govukButton({
+              text: "Continue"
+          }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/contact-do-you-have-an-email.html
+++ b/app/views/v2_1-citizen/3-details/contact-do-you-have-an-email.html
@@ -1,0 +1,68 @@
+
+{% extends "layout-live-nobanner.html" %}s
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        Do you have an email we can contact you on?
+      </h1>
+
+      <p></p>
+      <form action="contact-email" method="post">
+
+        {% set contactEmailYes %}
+          {{ govukInput({
+            label: {
+              text: "Enter an email address"
+            },
+            hint: {
+              text: "For example name@example.com"
+            },
+            classes: "govuk-input--width-20",
+            id: "contactemail-address",
+            name: "contactemail-address",
+            value: data['contactemail-address']
+          }) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: 'contact-email-address',
+          name: 'contact-email-address',
+          fieldset: {
+            legend: {
+              html: "<p>We'll use your email to contact you about your application.</p>",
+              isPageHeading: false,
+              classes: "govuk-body-l"
+            }
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("contact-email-address", "yes"),
+            conditional: {
+              html: contactEmailYes
+            }
+          }, {
+            value: "no",
+            checked: checked("contact-email-address", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/contact-email.html
+++ b/app/views/v2_1-citizen/3-details/contact-email.html
@@ -1,0 +1,68 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        Do you have an email we can contact you on?
+      </h1>
+
+      <p></p>
+      <form action="contact-email" method="post">
+
+        {% set contactEmailYes %}
+          {{ govukInput({
+            label: {
+              text: "Enter an email address"
+            },
+            hint: {
+              text: "For example name@example.com"
+            },
+            classes: "govuk-input--width-20",
+            id: "contactemail-address",
+            name: "contactemail-address",
+            value: data['contactemail-address']
+          }) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: 'contact-email-address',
+          name: 'contact-email-address',
+          fieldset: {
+            legend: {
+              html: "<p>We'll use your email to contact you about your application.</p>",
+              isPageHeading: false,
+              classes: "govuk-body-l"
+            }
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("contact-email-address", "yes"),
+            conditional: {
+              html: contactEmailYes
+            }
+          }, {
+            value: "no",
+            checked: checked("contact-email-address", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/contact-phone.html
+++ b/app/views/v2_1-citizen/3-details/contact-phone.html
@@ -1,0 +1,68 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        Do you have a phone number we can contact you on?
+      </h1>
+
+      <form action="contact-phone" method="post">
+
+        {% set contactPhoneYes %}
+          {{ govukInput({
+            label: {
+              text: "Enter a phone number"
+            },
+            hint: {
+              text: "For example 01632 960 001 or 07700 900 982"
+            },
+            classes: "govuk-input--width-10",
+            id: "telephone-number",
+            name: "telephone-number",
+            value: data['telephone-number']
+          }) }}
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: 'contact-telephone-number',
+          name: 'contact-telephone-number',
+          fieldset: {
+            legend: {
+              html: "<p>We will use your mobile number to contact you about your application. We can use a landline if you do not have a mobile.</p>
+              <p>Your claim could be delayed if you do not provide a phone number.</p>",
+              isPageHeading: false,
+              classes: "govuk-body-l"
+            }
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("contact-telephone-number", "yes"),
+            conditional: {
+              html: contactPhoneYes
+            }
+          }, {
+            value: "no",
+            checked: checked("contact-telephone-number", "no"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/dob.html
+++ b/app/views/v2_1-citizen/3-details/dob.html
@@ -1,0 +1,94 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        What is your date of birth?
+      </h1>
+
+      <form action="address" method="post">
+
+        {% if data['under16'] == "" %}
+
+        {% set errorArray = {
+          dob: { text: "Check date of birth"}
+        }%}
+
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": [
+            {
+              "text": 'You must be 16 or over to claim',
+              "href": '#dob-day'
+            }
+          ]
+        }) }}
+
+        {% endif %}
+
+        {% if data['over64'] == "" %}
+
+        {% set errorArray = {
+          dob: { text: "You must be under state pension age to claim"}
+        }%}
+
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": [
+            {
+              "text": 'You must be under state pension age to claim',
+              "href": '#dob-day'
+            }
+          ]
+        }) }}
+
+        {% endif %}
+
+        {{ govukDateInput({
+            id: 'dob',
+            name: 'dob',
+            hint: {
+                html: 'For example, 31 3 1980.'
+            },
+            items: [
+                {
+                name: 'dobDay',
+                value: data['dobDay'],
+                classes: 'govuk-input--width-2',
+                label: 'Day'
+                },
+                {
+                name: 'dobMonth',
+                value: data['dobMonth'],
+                classes: 'govuk-input--width-2',
+                label: 'Month'
+                },
+                {
+                name: 'dobYear',
+                value: data['dobYear'],
+                classes: 'govuk-input--width-4',
+                label: 'Year'
+                }
+            ],
+            errorMessage: errorArray.dob
+            })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/nino.html
+++ b/app/views/v2_1-citizen/3-details/nino.html
@@ -1,0 +1,48 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Personal details</span>
+        What is your National Insurance number?
+      </h1>
+    <p class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</p>
+
+      <form action="about-you" method="post">
+        {% call govukFieldset({
+        }) %}
+        {{ govukInput({
+            label: {
+                text: "National Insurance number",
+                classes: "govuk-visually-hidden"
+            },
+
+            classes: "govuk-input--width-20",
+            id: "national-insurance-number",
+            name: "national-insurance-number",
+            value: data['national-insurance-number']
+        }) }}
+        {{ govukDetails({
+            summaryText: "I cannot find my National Insurance number",
+            html: '<p>You can find your National Insurance number on your payslip, P60, or letters about tax, pensions and benefits. If you cannot find it you can <a href="https://www.gov.uk/lost-national-insurance-number">ask for a reminder through the post</a>.</p>
+            '
+        }) }}
+    {% endcall %}
+
+    {{ govukButton({
+        text: "Continue"
+    }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/3-details/under18.html
+++ b/app/views/v2_1-citizen/3-details/under18.html
@@ -1,0 +1,28 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">You cannot apply online for New Style Jobseeker's Allowance</h1>
+            <p>Contact Jobcentre Plus for help with your claim.</p>
+            <div class="contact">
+            <p><strong>Jobcentre Plus</strong><br>
+            Telephone: 0800 055 6688<br>
+            Textphone: 0800 023 4888<br>
+            <a href="http://ngts.org.uk/">NGT text relay</a> (if you cannot hear or speak on the phone): 18001 then 0800 055 6688<br>
+            Welsh language: 0800 012 1888<br>
+            Monday to Friday, 8am to 6pm<br>
+            <a href="/call-charges">Find out about call charges</a></p>
+            </div>
+            <p class="govuk-!-margin-top-6">If you are not sure which benefit to apply for you can check online.</p>
+            <p><a href="https://www.gov.uk/benefits-calculators">Find other benefits</a></p>
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/4-other-benefits/_routes.js
+++ b/app/views/v2_1-citizen/4-other-benefits/_routes.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/4-other-benefits';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/5-jury-service';
+
+// Redirect /education to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.obAreYou;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      res.redirect(`${ABS_BASE_PATH}/what-other-benefits`);
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/what-other-benefits', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/4-other-benefits/guard.html
+++ b/app/views/v2_1-citizen/4-other-benefits/guard.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Other benefits</span>
+        Have you applied for any other benefits in the last 12 weeks?
+      </h1>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          idPrefix: "ob-are-you",
+          name: "obAreYou",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "Yes",
+            checked: checked("obAreYou", "Yes"),
+            text: "Yes"
+          }, {
+            value: "No",
+            checked: checked("obAreYou", "No"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/4-other-benefits/what-other-benefits.html
+++ b/app/views/v2_1-citizen/4-other-benefits/what-other-benefits.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Other benefits</span>
+        Tell us what other benefits you have applied for in the last 12 weeks
+      </h1>
+
+      <form action="what-other-benefits" method="post">
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukCharacterCount({
+          name: "ob-more-detail",
+          id: "ob-more-detail",
+          maxlength: 100,
+          value: data['ob-more-detail'],
+          hint: {
+            html: "For example, Carer's Allowance"
+          }
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/5-jury-service/_routes.js
+++ b/app/views/v2_1-citizen/5-jury-service/_routes.js
@@ -1,0 +1,22 @@
+var express = require('express');
+var router = express.Router();
+
+// Redirect /jury-service to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect('/v2_1-citizen/5-jury-service/have-been');
+});
+
+router.post('/have-been', function (req, res) {
+  var juryConditional = req.body.juryService;
+  if (juryConditional === 'Yes') {
+    res.redirect('/v2_1-citizen/5-jury-service/period');
+  } else {
+    res.redirect('/v2_1-citizen/6-current-employment');
+  }
+});
+
+router.post('/period', function (req, res) {
+  res.redirect('/v2_1-citizen/6-current-employment');
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/5-jury-service/have-been.html
+++ b/app/views/v2_1-citizen/5-jury-service/have-been.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Jury service</span>
+        Have you been on jury service in the last 12 weeks?
+      </h1>
+
+      <form action="have-been" method="post">
+
+        {{ govukRadios({
+            classes: "govuk-radios--inline",
+            idPrefix: 'jury-service',
+            name: 'juryService',
+            items: [
+                {
+                    value: "Yes",
+                    checked: checked("juryService", "Yes"),
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    checked: checked("juryService", "No"),
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/5-jury-service/period.html
+++ b/app/views/v2_1-citizen/5-jury-service/period.html
@@ -1,0 +1,100 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Jury service</span>
+        When was this jury service?
+      </h1>
+
+      <form action="period" method="post">
+
+        {{ govukDateInput({
+          id: 'jury-service-start',
+          name: 'juryServiceStart',
+          fieldset: {
+            legend: {
+              text: 'Jury service start date',
+              isPageHeading: false,
+              classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+            html: 'For example, ' + todaysDate.original | moment('subtract', 12, 'months')
+          },
+          items: [
+            {
+              name: 'juryStartDay',
+              value: data['juryStartDay'],
+              classes: 'govuk-input--width-2',
+              label: 'Day'
+            },
+            {
+              name: 'juryStartMonth',
+              value: data['juryStartMonth'],
+              classes: 'govuk-input--width-2',
+              label: 'Month'
+            },
+            {
+              name: 'juryStartYear',
+              value: data['juryStartYear'],
+              classes: 'govuk-input--width-4',
+              label: 'Year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukDateInput({
+          id: 'jury-service-finish',
+          name: 'juryServiceFinish',
+          fieldset: {
+            legend: {
+              text: 'Jury service end date',
+              isPageHeading: false,
+              classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+            html: 'For example, ' + todaysDate.original | moment
+          },
+          items: [
+            {
+              name: 'juryFinishDay',
+              value: data['juryFinishDay'],
+              classes: 'govuk-input--width-2',
+              label: 'Day'
+            },
+            {
+              name: 'juryFinishMonth',
+              value: data['juryFinishMonth'],
+              classes: 'govuk-input--width-2',
+              label: 'Month'
+            },
+            {
+              name: 'juryFinishYear',
+              value: data['juryFinishYear'],
+              classes: 'govuk-input--width-4',
+              label: 'Year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/_routes.js
+++ b/app/views/v2_1-citizen/6-current-employment/_routes.js
@@ -1,0 +1,105 @@
+const express = require('express');
+const router = express.Router();
+const app = express();
+
+const BASE_PATH = 'v2_1-citizen/6-current-employment';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/7-previous-employment';
+
+const MAX_PREVIOUS_JOBS = 4;
+
+// Redirect /current-employment to first question in sequence
+router.all('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.ceCurrentlyWorking;
+  app.locals.currentJobCount = 1;
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      res.redirect(`${ABS_BASE_PATH}/type?job=1`);
+    } else if (answer === 'No') {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/type', function (req, res) {
+  const answer = req.body.ceCurrentWorkType;
+
+  if (answer === 'Paid') {
+    res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+  } else if (answer === 'Voluntary') {
+    res.redirect(`${ABS_BASE_PATH}/choose-to-be-paid`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+  }
+});
+
+router.post('/choose-to-be-paid', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/get-paid`);
+});
+
+router.post('/get-paid', function (req, res) {
+  const answer = req.body.ceGetPaid;
+
+  if (answer === 'ce-get-paid-no') {
+    res.redirect(`${ABS_BASE_PATH}/employer-name`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+  }
+});
+
+router.post('/payment-frequency', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/employer-name`);
+});
+
+router.post('/employer-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/employer-address`);
+});
+
+router.post('/employer-address', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/hours`);
+});
+
+router.post('/employer-contact', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/hours`);
+});
+
+router.post('/hours', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/self-employed-or-company-director`);
+});
+
+router.post('/self-employed-or-company-director', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/another-one`);
+});
+
+router.post('/another-one', function (req, res) {
+  const answer = req.body.ceAnotherJob;
+
+  if (answer === 'ce-another-job-yes') {
+    app.locals.currentJobCount = typeof app.locals.currentJobCount === 'undefined' ? 1 : ++app.locals.currentJobCount;
+    if (app.locals.currentJobCount === MAX_PREVIOUS_JOBS) {
+      res.redirect(`${ABS_BASE_PATH}/employer-limit-warning`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/type?job=` + app.locals.currentJobCount);
+    }
+  } else {
+    res.redirect(NEXT_PATH);
+  }
+});
+
+router.get('/employer-limit-warning', function (req, res) {
+  res.render(`${BASE_PATH}/employer-limit-warning`, {
+    maxPreviousJobs: MAX_PREVIOUS_JOBS.toString()
+  });
+});
+
+router.post('/employer-limit-warning', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/6-current-employment/another-one.html
+++ b/app/views/v2_1-citizen/6-current-employment/another-one.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Do you have another current paid or voluntary job?
+      </h1>
+
+      <form action="another-one" method="post">
+
+        {{ govukRadios({
+          idPrefix: "ce-another-job",
+          name:  "ceAnotherJob",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "ce-another-job-yes",
+            text: "Yes"
+          }, {
+            value: "ce-another-job-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/choose-to-be-paid.html
+++ b/app/views/v2_1-citizen/6-current-employment/choose-to-be-paid.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Can you choose if you’re paid for this voluntary work?
+      </h1>
+
+      <form action="choose-to-be-paid" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-voluntary-work-can-you-choose",
+          name: "ceVoluntaryWorkCanYouChoose",
+          items: [{
+            value: "ce-voluntary-work-can-you-choose-yes",
+            text: "Yes",
+            checked: checked("ceVoluntaryWorkCanYouChoose", "ce-voluntary-work-can-you-choose-yes")
+          },
+          {
+            value: "ce-voluntary-work-can-you-choose-no",
+            text: "No",
+            checked: checked("ceVoluntaryWorkCanYouChoose", "ce-voluntary-work-can-you-choose-no")
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/employer-address.html
+++ b/app/views/v2_1-citizen/6-current-employment/employer-address.html
@@ -1,0 +1,72 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        What is the address of your current employer?
+      </h1>
+
+      <form action="employer-address" method="post">
+
+        <!-- {% set jobref = "job" + data["jobnum"] + "-" %} -->
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>"
+          },
+          id: "ce-address-line-1",
+          name: "ce-address-line-1",
+          value: data['ce-address-line-1']
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>"
+          },
+          id: "ce-address-line-2",
+          name: "ce-address-line-2",
+          value: data['ce-address-line-2']
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Town or city"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "ce-address-town",
+          name: "ce-address-town",
+          value: data['ce-address-town']
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Postcode (optional)"
+          },
+          classes: "govuk-input--width-10",
+          id: "ce-address-postcode",
+          name: "ce-address-postcode",
+          value: data['ce-address-postcode']
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/employer-contact.html
+++ b/app/views/v2_1-citizen/6-current-employment/employer-contact.html
@@ -1,0 +1,45 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        What is the phone number of your current employer? (optional)
+      </h1>
+
+      <form action="employer-contact" method="post">
+
+        {% set jobref = "job" + data["jobnum"] + "-" %}
+        {% set fieldref = jobref + "ce-telephone-number" %}
+        {% call govukFieldset({
+        }) %}
+
+          {{ govukInput({
+            label: {
+              text: ""
+            },
+            id: "ce-telephone-number",
+            name: fieldref,
+            type: "tel",
+            classes: "govuk-input--width-20",
+            value: data[fieldref]
+          }) }}
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/employer-limit-warning.html
+++ b/app/views/v2_1-citizen/6-current-employment/employer-limit-warning.html
@@ -1,0 +1,26 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="employer-limit-warning" method="post">
+
+        <h1 class="govuk-heading-l">You have entered a maximum of {{ maxPreviousJobs }} jobs</h1>
+        <p>If you have more, please bring evidence of these to your job centre interview</p>
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/employer-name.html
+++ b/app/views/v2_1-citizen/6-current-employment/employer-name.html
@@ -1,0 +1,48 @@
+
+{% extends "layout-live-nobanner.html" %}s
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        What is the name of your current employer?
+      </h1>
+
+      <form action="employer-name" method="post">
+
+        {% set jobref = "job" + data["jobnum"] + "-" %}
+        {% set fieldref = jobref + "ceEmployerName" %}
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Current employer name",
+            classes: "govuk-visually-hidden"
+          },
+          hint: {
+            text: ""
+          },
+          id: "employer-name",
+          name: "employer-name",
+          value: data['employer-name'],
+          classes: "govuk-input--width-20"
+        }) }}
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/get-paid.html
+++ b/app/views/v2_1-citizen/6-current-employment/get-paid.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Do you get paid for this voluntary work?
+      </h1>
+
+      <form action="get-paid" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-get-paid",
+          name: "ceGetPaid",
+          items: [{
+            value: "yes",
+            text: "Yes",
+            checked: checked("ceGetPaid", "ce-get-paid-yes")
+          },
+          {
+            value: "ce-get-paid-no",
+            text: "No",
+            checked: checked("ceGetPaid", "ce-get-paid-no")
+          }]
+        })}}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/guard.html
+++ b/app/views/v2_1-citizen/6-current-employment/guard.html
@@ -1,0 +1,50 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Are you in any form of work at the moment?
+      </h1>
+      <span class="govuk-hint">
+        This includes paid or voluntary work.
+      </span>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-currently-working",
+          name: "ceCurrentlyWorking",
+          hint: {
+            text: ""
+          },
+          items: [{
+            value: "Yes",
+            checked: checked("ceCurrentlyWorking", "Yes"),
+            text: "Yes"
+          },
+          {
+            value: "No",
+            checked: checked("ceCurrentlyWorking", "No"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/hours.html
+++ b/app/views/v2_1-citizen/6-current-employment/hours.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        How many hours a week do you normally work in this job?
+      </h1>
+
+      <form action="hours" method="post">
+
+        <!-- {% set jobref = "job" + data["jobnum"] + "-" %} -->
+
+        {% call govukFieldset({
+        }) %}
+
+        <p class="govuk-hint">Enter your average hours as a whole number, rounded down to the nearest hour</p>
+
+        <div class="govuk-form-group govuk-short-input">
+            <label class="govuk-label govuk-visually-hidden" for="ce-hours-worked-a-week">Average hours worked a week</label>
+            <input value="{{ data['ceHoursWorkedAWeek'] }}" class="govuk-input govuk-input--width-3 govuk-!-margin-right-2" id="ce-hours-worked-a-week" name="ceHoursWorkedAWeek" type="number" maxlength="2">
+            <span class="govuk-body">hours</span>
+        </div>
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/payment-frequency.html
+++ b/app/views/v2_1-citizen/6-current-employment/payment-frequency.html
@@ -1,0 +1,159 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+{#
+<p><strong>
+Note: The pound sign needs to be inside the input text box, this is styled by macros/macros.njk
+</strong></p>
+#}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        How often are you paid?
+      </h1>
+
+      <form action="payment-frequency" method="post">
+
+        <div class="govuk-form-group">
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-work-paid" name="current-work-paid" type="radio" value="Weekly" data-aria-controls="conditional-current-work-paid" {{ checked("current-work-paid", "Weekly") }}>
+                <label class="govuk-label govuk-radios__label" for="current-work-paid">
+                  Weekly
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-work-paid">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-work-paid-weekly">
+                    <strong>What is your net pay?<br></strong>
+                    This is the exact amount that is paid into your bank account
+                  </label>
+                  <div id="current-work-paid-weekly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <input class="govuk-input govuk-!-width-one-third" id="current-work-paid-weekly-amount" name="current-work-paid-weekly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-work-paid-weekly-amount'] }}">
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-work-paid-2" name="current-work-paid" type="radio" value="Every 2 weeks" data-aria-controls="conditional-current-work-paid-2" {{ checked("current-work-paid", "Every 2 weeks") }}>
+                <label class="govuk-label govuk-radios__label" for="current-work-paid">
+                  Every 2 weeks
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-work-paid-2">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-work-paid-weekly">
+                    <strong>What is your net pay?<br></strong>
+                    This is the exact amount that is paid into your bank account
+                  </label>
+                  <div id="current-work-paid-weekly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <input class="govuk-input govuk-!-width-one-third" id="current-work-paid-weekly-amount" name="current-work-paid-fortnightly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-work-paid-fortnightly-amount'] }}">
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-work-paid-3" name="current-work-paid" type="radio" value="Every 3 weeks" data-aria-controls="conditional-current-work-paid-3" {{ checked("current-work-paid", "Every 3 weeks") }}>
+                <label class="govuk-label govuk-radios__label" for="current-work-paid">
+                  Every 3 weeks
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-work-paid-3">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-work-paid-weekly">
+                    <strong>What is your net pay?<br></strong>
+                    This is the exact amount that is paid into your bank account
+                  </label>
+                  <div id="current-work-paid-weekly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <input class="govuk-input govuk-!-width-one-third" id="current-work-paid-weekly-amount" name="current-work-paid-3weeks-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-work-paid-3weeks-amount'] }}">
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-work-paid-4" name="current-work-paid" type="radio" value="Every month" data-aria-controls="conditional-current-work-paid-4" {{ checked("current-work-paid", "Every month") }}>
+                <label class="govuk-label govuk-radios__label" for="current-work-paid">
+                  Every month
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-work-paid-4">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-work-paid-weekly">
+                    <strong>What is your net pay?<br></strong>
+                    This is the exact amount that is paid into your bank account
+                  </label>
+                  <div id="current-work-paid-weekly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <input class="govuk-input govuk-!-width-one-third" id="current-work-paid-weekly-amount" name="current-work-paid-monthly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-work-paid-monthly-amount'] }}">
+                </div>
+              </div>
+            </div>
+        </div>
+
+        <!-- {% set jobref = "job" + data["jobnum"] + "-" %}
+        {% set prefix = jobref + "current-employment-" %}
+
+        {{ govukRadios({
+          idPrefix: "current-work-paid",
+          name: jobref + "currentWorkPaid",
+          items: [{
+            value: "Weekly",
+            text: "Every week",
+            checked: checked(jobref + "currentWorkPaid", "Weekly"),
+            conditional: {
+              html: netPaymentAmountInput(prefix, "weekly")
+            }
+          }, {
+            value: "Fortnightly",
+            text: "Every 2 weeks",
+            checked: checked(jobref + "currentWorkPaid", "Fortnightly"),
+            conditional: {
+              html: netPaymentAmountInput(prefix, "fortnightly")
+            }
+          }, {
+            value: "FourWeekly",
+            text: "Every 4 weeks",
+            checked: checked(jobref + "currentWorkPaid", "FourWeekly"),
+            conditional: {
+              html: netPaymentAmountInput(prefix, "four-weekly")
+            }
+          }, {
+            value: "Monthly",
+            text: "Every month",
+            checked: checked(jobref + "currentWorkPaid", "Monthly"),
+            conditional: {
+              html: netPaymentAmountInput(prefix, "monthly")
+            }
+          }]
+        })}} -->
+
+      <!-- save the value from the last screen with the current job no -->
+      <!-- {{ govukInput({
+          type: "hidden",
+          id: jobref + "ceCurrentWorkType",
+          name: jobref + "ceCurrentWorkType",
+          value: data["ceCurrentWorkType"]
+        })  }} -->
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/self-employed-or-company-director.html
+++ b/app/views/v2_1-citizen/6-current-employment/self-employed-or-company-director.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Are you self-employed or a company director in this job?
+      </h1>
+
+      <form action="self-employed-or-company-director" method="post">
+
+        {{ govukRadios({
+          idPrefix: "ce-self-employed-or-company-director",
+          name: "ceSelfEmployedOrCompanyDirector",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "Yes",
+            text: "Yes",
+            checked: checked("ceSelfEmployedOrCompanyDirector", "Yes")
+          }, {
+            value: "No",
+            text: "No",
+            checked: checked("ceSelfEmployedOrCompanyDirector", "No")
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/6-current-employment/type.html
+++ b/app/views/v2_1-citizen/6-current-employment/type.html
@@ -1,0 +1,73 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current employment</span>
+        Is this paid or voluntary?
+      </h1>
+      <span class="govuk-hint">
+     If you have more than one job you will be able to tell us about the others later.
+  </span>
+
+      <form action="type" method="post">
+
+        {% set jobref = "job" + data["jobnum"] + "-" %}
+
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "ce-current-work-type",
+          name: "ceCurrentWorkType",
+          items: [{
+            value: "Paid",
+            text: "Paid work",
+            checked: checked("ceCurrentWorkType", "Paid")
+          }, {
+            value: "Voluntary",
+            text: "Voluntary work",
+            checked: checked("ceCurrentWorkType", "Voluntary")
+          }]
+          })
+        }}
+
+        {{ govukInput({
+          type: "hidden",
+          id: "jobnum",
+          name: "jobnum"
+        })  }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+<!-- save current job number -->
+<script language="javascript">
+  window.onload = function() {
+    document.getElementById('jobnum').value = getParameterByName("job");
+}
+
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, '\\$&');
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}
+
+</script>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/_routes.js
+++ b/app/views/v2_1-citizen/7-previous-employment/_routes.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const router = express.Router();
+
+const MAX_PREVIOUS_JOBS = 4;
+
+const BASE_PATH = 'v2_1-citizen/7-previous-employment';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/8-abroad';
+
+/*
+ * Branching for previous employment
+ * */
+
+// Redirect /previous-employment to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect('/v2_1-citizen/7-previous-employment/job-ended-last-six-months');
+});
+
+// After last 6 months we ask when did you work for employer
+router.get('/when-employer', function (req, res) {
+  var lastSixMonths = req.query.peLastSixMonths;
+  if (lastSixMonths === 'No') {
+    res.redirect(NEXT_PATH);
+  } else {
+    res.render(`${BASE_PATH}/when-employer`);
+  }
+});
+
+// Afer when did you work for this employer we ask why did this job end
+router.get('/why-end', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/why-did-it-end`);
+});
+
+// After why did this job end we ask the employer name
+router.get('/name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/employer-name`);
+});
+
+// After asking the employer name we ask for their address
+router.get('/address', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/employer-address`);
+});
+
+// After asking for their address we ask for the employer contact number
+router.get('/contact', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/employer-contact`);
+});
+
+// After asking for the empoyer contact number we ask if any payment is expected
+router.get('/expect-payment', function (req, res) {
+  const peExpectPayment = req.query.peExpectPayment;
+  // We want a 'yes' or a 'no' answer here
+  if (!peExpectPayment) {
+    res.render(`${BASE_PATH}/expect-payment`);
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/self-employed-or-company-director`);
+  }
+});
+
+// After expecting any payment we ask if they were a company director or self-employed
+router.post('/self-employed-or-company-director', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/another-job-ended-last-six-months`);
+});
+
+// After asking if they were a company directot or self-employed we ask if you had another job that ended in last 6 months
+router.post('/another-job-ended-last-six-months', function (req, res) {
+  const answer = req.body.peAnotherLastSixMonths;
+  if (answer === 'yes') {
+    res.redirect(`${ABS_BASE_PATH}/when-employer`);
+  } else {
+    res.redirect(NEXT_PATH);
+  }
+});
+
+// Counter, although unsure if it actually works due to reliance on a module that isn't available
+router.get('/employer-limit-warning', function (req, res) {
+  res.render(`${BASE_PATH}/employer-limit-warning`, {
+    maxPreviousJobs: MAX_PREVIOUS_JOBS.toString()
+  });
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/7-previous-employment/another-job-ended-last-six-months.html
+++ b/app/views/v2_1-citizen/7-previous-employment/another-job-ended-last-six-months.html
@@ -1,0 +1,45 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Have you had another job that has ended in the past 6 months?
+      </h1>
+
+      <form action="another-job-ended-last-six-months" method="post">
+
+        {{ govukRadios({
+            idPrefix: 'pe-another-last-six-months',
+            name: 'peAnotherLastSixMonths',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "yes",
+                    text: "Yes"
+                },
+                {
+                    value: "no",
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/employer-address.html
+++ b/app/views/v2_1-citizen/7-previous-employment/employer-address.html
@@ -1,0 +1,72 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        What is the address of your previous employer?
+      </h1>
+
+      <form action="expect-payment" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+            label: {
+            html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+            },
+            id: "pe-address-line-1",
+            name: "pe-address-line-1",
+            value: data['pe-address-line-1']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+            },
+            id: "pe-address-line-2",
+            name: "pe-address-line-2",
+            value: data['pe-address-line-2']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            text: 'Town or city'
+            },
+            classes: 'govuk-!-width-two-thirds',
+            id: "pe-address-town",
+            name: "pe-address-town",
+            value: data['pe-address-town']
+        }) }}
+
+        {{ govukInput({
+            label: {
+            text: 'Postcode (optional)'
+            },
+            classes: 'govuk-input--width-10',
+            id: "pe-address-postcode",
+            name: "pe-address-postcode",
+            value: data['pe-address-postcode']
+        }) }}
+
+        {% endcall %}
+
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/employer-contact.html
+++ b/app/views/v2_1-citizen/7-previous-employment/employer-contact.html
@@ -1,0 +1,46 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        What is the phone number of your previous employer? (optional)
+      </h1>
+
+      <form action="expect-payment" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        <p class="govuk-hint">Supply a contact number to a person or department who will be able to confirm your employment there.</p>
+
+          {{ govukInput({
+            label: {
+               text: ""
+            },
+            id: "pe-telephone-number",
+            name: "pe-telephone-number",
+            type: "tel",
+            classes: "govuk-input--width-20",
+            value: data['pe-telephone-number']
+          }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/employer-limit-warning.html
+++ b/app/views/v2_1-citizen/7-previous-employment/employer-limit-warning.html
@@ -1,0 +1,26 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="outside-uk">
+
+        <h1 class="govuk-heading-l">You have entered {{ maxPreviousJobs }} maximum jobs</h1>
+        <p>If you did have more than {{ maxPreviousJobs }} in last 6 months, please bring evidence of these to your JSA interview.</p>
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/employer-name.html
+++ b/app/views/v2_1-citizen/7-previous-employment/employer-name.html
@@ -1,0 +1,44 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        What is the name of your previous employer?
+      </h1>
+
+      <form action="address" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+            {{ govukInput({
+                label: {
+                    text: "Previous employer name",
+                    classes: "govuk-visually-hidden"
+                },
+                classes: "govuk-input--width-20",
+                id: "pe-employer-name",
+                name: "peEmployerName",
+                value: data['peEmployerName']
+            }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/expect-payment.html
+++ b/app/views/v2_1-citizen/7-previous-employment/expect-payment.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Do you expect to receive any more payments from this job?
+      </h1>
+
+      <form action="expect-payment">
+
+        {{ govukRadios({
+            idPrefix: 'pe-expect-payment',
+            name: 'peExpectPayment',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "Yes",
+                    checked: checked("peExpectPayment", "Yes"),
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    checked: checked("peExpectPayment", "No"),
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/job-ended-last-six-months.html
+++ b/app/views/v2_1-citizen/7-previous-employment/job-ended-last-six-months.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Have you had a job that ended in the last 6 months?
+      </h1>
+
+      <form action="when-employer" method="get">
+
+        {{ govukRadios({
+            idPrefix: 'pe-last-six-months',
+            name: 'peLastSixMonths',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "Yes",
+                    checked: checked("peLastSixMonths", "Yes"),
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    checked: checked("peLastSixMonths", "No"),
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/self-employed-or-company-director.html
+++ b/app/views/v2_1-citizen/7-previous-employment/self-employed-or-company-director.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Were you self-employed or a company director?
+      </h1>
+
+      <form action="self-employed-or-company-director" method="post">
+
+        {{ govukRadios({
+            idPrefix: 'pe-self-employed-or-company-director',
+            name: 'peSelfEmployedOrCompanyDirector',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "Yes",
+                    checked: checked("peSelfEmployedOrCompanyDirector", "Yes"),
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    checked: checked("peSelfEmployedOrCompanyDirector", "No"),
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/when-employer.html
+++ b/app/views/v2_1-citizen/7-previous-employment/when-employer.html
@@ -1,0 +1,100 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        When did you work for this employer?
+      </h1>
+
+      <form action="why-end" method="post">
+
+        {{ govukDateInput({
+          id: 'pe-when-employer-start',
+          name: 'peWhenEmployerStart',
+          fieldset: {
+            legend: {
+                text: 'Enter the employment start date',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+              text: "For example, 31 3 2018"
+          },
+          items: [
+            {
+              name: 'peStartDay',
+              value: data['peStartDay'],
+              classes: 'govuk-input--width-2',
+              label: 'Day'
+            },
+            {
+              name: 'peStartMonth',
+              value: data['peStartMonth'],
+              classes: 'govuk-input--width-2',
+              label: 'Month'
+            },
+            {
+              name: 'peStartYear',
+              value: data['peStartYear'],
+              classes: 'govuk-input--width-4',
+              label: 'Year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukDateInput({
+          id: 'pe-when-employer-finish',
+          name: 'peWhenEmployerFinish',
+          fieldset: {
+            legend: {
+                text: 'Enter the employment end date',
+                isPageHeading: false,
+                classes: 'govuk-fieldset__legend--m'
+            }
+          },
+          hint: {
+              text: "For example, 31 3 2018"
+          },
+          items: [
+            {
+              name: 'peFinishDay',
+              value: data['peFinishDay'],
+              classes: 'govuk-input--width-2',
+              label: 'Day'
+            },
+            {
+              name: 'peFinishMonth',
+              value: data['peFinishMonth'],
+              classes: 'govuk-input--width-2',
+              label: 'Month'
+            },
+            {
+              name: 'peFinishYear',
+              value: data['peFinishYear'],
+              classes: 'govuk-input--width-4',
+              label: 'Year'
+            }
+          ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/7-previous-employment/why-did-it-end.html
+++ b/app/views/v2_1-citizen/7-previous-employment/why-did-it-end.html
@@ -1,0 +1,74 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Why did this job end?
+      </h1>
+
+      <form action="name" method="post">
+
+        {% set peOtherHtml %}
+            {{ govukCharacterCount({
+              name: "pe-more-detail",
+              id: "pe-more-detail",
+              value: data['pe-more-detail'],
+              label: {
+                text: "Can you provide more detail about why this job ended?"
+              },
+              maxlength: 200
+        }) }}
+
+        {% endset -%}
+
+        {{ govukRadios({
+          idPrefix: 'pe-why-end',
+          name: 'peWhyEnd',
+          items: [{
+            value: "Redundancy",
+            checked: checked("peWhyEnd", "Redundancy"),
+            text: "Redundancy"
+          }, {
+            value: "Long term sickness",
+            checked: checked("peWhyEnd", "Long term sickness"),
+            text: "Long term sickness"
+          }, {
+            value: "Dismissal",
+            checked: checked("peWhyEnd", "Dismissal"),
+            text: "Dismissal"
+          }, {
+            value: "Left voluntarily",
+            checked: checked("peWhyEnd", "Left voluntarily"),
+            text: "Left voluntarily"
+          }, {
+            value: "End of contract",
+            checked: checked("peWhyEnd", "End of contract"),
+            text: "End of contract"
+          }, {
+            value: "Other",
+            checked: checked("peWhyEnd", "Other"),
+            text: "Other",
+            conditional: {
+              html: peOtherHtml
+            }
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/8-abroad/_routes.js
+++ b/app/views/v2_1-citizen/8-abroad/_routes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'v2_1-citizen/8-abroad';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/9-pensions';
+
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  res.redirect(`${NEXT_PATH}`);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/8-abroad/guard.html
+++ b/app/views/v2_1-citizen/8-abroad/guard.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Previous employment</span>
+        Have you worked or claimed benefit outside of the United Kingdom in the last 4 years?
+      </h1>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+            idPrefix: 'abroad',
+            name: 'workBenefitAbroad',
+            classes: "govuk-radios--inline",
+            items: [
+                {
+                    value: "Yes",
+                    checked: checked("workBenefitAbroad", "Yes"),
+                    text: "Yes"
+                },
+                {
+                    value: "No",
+                    checked: checked("workBenefitAbroad", "No"),
+                    text: "No"
+                }
+            ]
+          })
+        }}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/_routes.js
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/_routes.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const router = express.Router();
+//const pensionTracker = require('pension-tracker');
+
+const LIMIT_WARNING_PATH = '/v2_1-citizen/9-pensions/limit-warning';
+const BASE_PATH = 'v2_1-citizen/9-pensions/9a-current-pension';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/10-education';
+
+// Track which type of pension the user is interacting with
+router.all('/*', function (req, res) {
+  //pensionTracker.setCurrentType(pensionTracker.PENSION_TYPES.CURRENT);
+  req.next();
+});
+
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.currentPensionGuard;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/when-start', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+});
+
+router.post('/payment-frequency', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/increase-does-it`);
+});
+
+router.post('/increase-does-it', function (req, res) {
+  const answer = req.body.currentPensionDoesItIncrease;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'Yes') {
+      res.redirect(`${ABS_BASE_PATH}/increase-when`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/another-one`);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/increase-does-it`);
+  }
+});
+
+router.post('/increase-when', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/another-one`);
+});
+
+router.post('/increase-frequency', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/increase-when`);
+});
+
+router.post('/provider-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/provider-address`);
+});
+
+router.post('/provider-address', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+});
+
+router.post('/another-one', function (req, res) {
+  const answer = req.body.currentPensionAnotherOne;
+
+  if (typeof answer !== 'undefined') {
+    //pensionTracker.add();
+
+    if (answer === 'current-pension-another-one-yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/another-one`);
+  }
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/another-one.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/another-one.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        Do you have another pension or annuity you currently receive?
+      </h1>
+
+      <form action="another-one" method="post">
+
+        {{ govukRadios({
+          idPrefix: "current-pension-another-one",
+          name: "currentPensionAnotherOne",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "current-pension-another-one-yes",
+            text: "Yes"
+          }, {
+            value: "current-pension-another-one-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/guard.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/guard.html
@@ -1,0 +1,49 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Current pension</span>
+        Are you getting money from a pension or annuity?
+      </h1>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          idPrefix: "current-pension-guard",
+          name: "currentPensionGuard",
+          classes: "govuk-radios--inline",
+          hint: {
+            html: '<p>If you have more than one pension or annuity you will be able to tell us about the others later. You can enter them in any order.</p>
+            <p>A <strong>pension</strong> represents the savings you draw on after you retire from a job, or reach retirement age.</p>
+            <p>An <strong>annuity</strong> is an insurance product that allows you to swap your pension savings for a guaranteed regular income that will last for the rest of your life.</p>
+            '
+          },
+          items: [{
+            value: "Yes",
+            checked: checked("currentPensionGuard", "Yes"),
+            text: "Yes"
+          }, {
+            value: "No",
+            checked: checked("currentPensionGuard", "No"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/increase-does-it.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/increase-does-it.html
@@ -1,0 +1,43 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        Does your pension or annuity increase in the next six months?
+      </h1>
+
+      <form action="increase-does-it" method="post">
+
+        {{ govukRadios({
+          idPrefix: "current-pension-does-it-increase",
+          name: "currentPensionDoesItIncrease",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "Yes",
+            checked: checked("currentPensionDoesItIncrease", "Yes"),
+            text: "Yes"
+          }, {
+            value: "No",
+            checked: checked("currentPensionDoesItIncrease", "No"),
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/increase-when.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/increase-when.html
@@ -1,0 +1,35 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        When will your pension or annuity increase?
+      </h1>
+
+      <form action="increase-when" method="post">
+
+        {{ govukRadios({
+          idPrefix: "current-pension-increase-frequency",
+          name: "current-pension-increase-frequency",
+          items: TODAYS_DATE.month | getNextSixMonths,
+          checked: checked("current-pension-increase-frequency")
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/payment-frequency.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/payment-frequency.html
@@ -1,0 +1,200 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+{#
+<p><strong>
+Note: The pound sign needs to be inside the input text box, this is styled by macros/macros.njk
+</strong></p>
+#}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        How often is your pension or annuity paid?
+      </h1>
+
+      <form action="payment-frequency" method="post">
+
+        <div class="govuk-form-group">
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid" name="current-pension-paid" type="radio" value="Weekly" data-aria-controls="conditional-current-pension-paid" {{ checked("current-pension-paid", "Every week") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Every week
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-weekly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-weekly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-weekly-amount" name="current-pension-paid-weekly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-weekly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-2" name="current-pension-paid" type="radio" value="Every 2 weeks" data-aria-controls="conditional-current-pension-paid-2" {{ checked("current-pension-paid", "Every 2 weeks") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Every 2 weeks
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-2">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-fortnightly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-fortnightly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-fortnightly-amount" name="current-pension-paid-fortnightly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-fortnightly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-3" name="current-pension-paid" type="radio" value="Every 4 weeks" data-aria-controls="conditional-current-pension-paid-3" {{ checked("current-pension-paid", "Every 4 weeks") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Every 4 weeks
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-3">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-4weeks">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-4weeks-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-4weeks-amount" name="current-pension-paid-4weeks-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-4weeks-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-4" name="current-pension-paid" type="radio" value="Every month" data-aria-controls="conditional-current-pension-paid-4" {{ checked("current-pension-paid", "Every month") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Every month
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-4">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-monthly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-monthly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-monthly-amount" name="current-pension-paid-monthly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-monthly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-5" name="current-pension-paid" type="radio" value="Every 3 months" data-aria-controls="conditional-current-pension-paid-5" {{ checked("current-pension-paid", "Every 3 months") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Every 3 months
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-5">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-3monthly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-3monthly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-3monthly-amount" name="current-pension-paid-3monthly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-3monthly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-6" name="current-pension-paid" type="radio" value="Twice a year" data-aria-controls="conditional-current-pension-paid-6" {{ checked("current-pension-paid", "Twice a year") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Twice a year
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-6">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-twiceyearly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-twiceyearly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-twiceyearly-amount" name="current-pension-paid-twiceyearly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-twiceyearly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="current-pension-paid-7" name="current-pension-paid" type="radio" value="Once a year" data-aria-controls="conditional-current-pension-paid-7" {{ checked("current-pension-paid", "Once a year") }}>
+                <label class="govuk-label govuk-radios__label" for="current-pension-paid">
+                  Once a year
+                </label>
+              </div>
+              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-current-pension-paid-7">
+                <div class="govuk-form-group">
+                  <label class="govuk-label" for="current-pension-paid-yearly">
+                    <strong>What’s your gross pension?<br></strong>
+                    This is the total amount before tax is taken off.<br>
+                    You can find this on your pension statement.
+                  </label>
+                  <div id="current-pension-paid-yearly-hint" class="govuk-hint">
+                    For example, £80.00
+                  </div>
+                  <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+                    <input class="govuk-input govuk-input--width-5" id="current-pension-paid-yearly-amount" name="current-pension-paid-yearly-amount" type="numeric" spellcheck="false" autocomplete="email" value="{{ data['current-pension-paid-yearly-amount'] }}">
+                  </div>
+                </div>
+              </div>
+            </div>
+        </div>
+
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/provider-address.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/provider-address.html
@@ -1,0 +1,70 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        What is the address of your pension or annuity provider?
+      </h1>
+
+      <form action="provider-address" method="post">
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>"
+          },
+          id: "current-pension-address-line-1",
+          name: "current-pension-address-line-1",
+          value: data["current-pension-address-line-1"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>"
+          },
+          id: "current-pension-address-line-2",
+          name: "current-pension-address-line-2",
+          value: data["current-pension-address-line-2"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Town or city"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "current-pension-address-town",
+          name: "current-pension-address-town",
+          value: data["current-pension-address-town"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Postcode (optional)"
+          },
+          classes: "govuk-input--width-10",
+          id: "current-pension-address-postcode",
+          name: "current-pension-address-postcode",
+          value: data["current-pension-address-postcode"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9a-current-pension/provider-name.html
+++ b/app/views/v2_1-citizen/9-pensions/9a-current-pension/provider-name.html
@@ -1,0 +1,46 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Pension or annuity</span>
+        What is the name of your pension or annuity provider?
+      </h1>
+
+      <form action="provider-name" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Name of your current pension provider",
+            classes: "govuk-visually-hidden"
+          },
+          hint: {
+            text: ""
+          },
+          classes: "govuk-input--width-20",
+          id: "current-pension-provider-name",
+          name: "current-pension-provider-name",
+          value: data["current-pension-provider-name"]
+        }) }}
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/_routes.js
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/_routes.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const router = express.Router();
+//const pensionTracker = require('pension-tracker');
+
+const LIMIT_WARNING_PATH = '/v2_1-citizen/9-pensions/limit-warning';
+const BASE_PATH = 'v2_1-citizen/9-pensions/9b-deferred-pension';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/9-pensions/9c-future-pension';
+
+// Track which type of pension the user is interacting with
+router.all('/*', function (req, res) {
+  //pensionTracker.setCurrentType(pensionTracker.PENSION_TYPES.DEFERRED);
+  req.next();
+});
+
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.deferredPensionGuard;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'deferred-pension-guard-yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/when-start', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+});
+
+router.post('/payment-frequency', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/another-one`);
+});
+
+router.post('/provider-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/provider-address`);
+});
+
+router.post('/provider-address', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+});
+
+router.post('/another-one', function (req, res) {
+  const answer = req.body.deferredPensionAnotherOne;
+
+  if (typeof answer !== 'undefined') {
+    //pensionTracker.add();
+
+    if (answer === 'deferred-pension-another-one-yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/another-one`);
+  }
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/another-one.html
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/another-one.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Deferred pension</span>
+        Do you have another pension or annuity that you could be paid now, but have decided not to take?
+      </h1>
+
+      <form action="another-one" method="post">
+
+        {{ govukRadios({
+          idPrefix: "deferred-pension-another-one",
+          name: "deferredPensionAnotherOne",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "deferred-pension-another-one-yes",
+            text: "Yes"
+          }, {
+            value: "deferred-pension-another-one-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/guard.html
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/guard.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Deferred pension</span>
+        Do you have a pension or annuity that you could be paid now but have decided not to take?
+      </h1>
+
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          idPrefix: "deferred-pension-guard",
+          name: "deferredPensionGuard",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "deferred-pension-guard-yes",
+            text: "Yes"
+          }, {
+            value: "deferred-pension-guard-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/payment-frequency.html
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/payment-frequency.html
@@ -1,0 +1,91 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+{#
+<p><strong>
+Note: The pound sign needs to be inside the input text box, this is styled by macros/macros.njk
+</strong></p>
+#}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Deferred pension</span>
+        How often should your deferred pension or annuity be paid?
+      </h1>
+
+      <form action="payment-frequency" method="post">
+
+        {% set prefix = "deferred-pension" %}
+
+        {{ govukRadios({
+          idPrefix: "deferred-work-paid",
+          name: "deferredPensionPaid",
+          items: [{
+            value: "Weekly",
+            text: "Every week",
+            checked: checked("deferredPensionPaid", "Weekly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "weekly")
+            }
+          }, {
+            value: "Fortnightly",
+            text: "Every 2 weeks",
+            checked: checked("deferredPensionPaid", "Fortnightly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "fortnightly")
+            }
+          }, {
+            value: "FourWeekly",
+            text: "Every 4 weeks",
+            checked: checked("deferredensionPaid", "FourWeekly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "four-weekly")
+            }
+          }, {
+            value: "Monthly",
+            text: "Every month",
+            checked: checked("deferredPensionPaid", "Monthly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "monthly")
+            }
+          }, {
+            value: "Quarterly",
+            text: "Every 3 months",
+            checked: checked("deferredPensionPaid", "Quarterly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "quarterly")
+            }
+          }, {
+            value: "BiAnnually",
+            text: "Twice a year",
+            checked: checked("deferredPensionPaid", "BiAnnually"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "bi-annually")
+            }
+          }, {
+            value: "Annually",
+            text: "Once a year",
+            checked: checked("deferredPensionPaid", "Annually"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "annually")
+            }
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/provider-address.html
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/provider-address.html
@@ -1,0 +1,71 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Deferred pension</span>
+        What is the address of your pension or annuity provider?
+      </h1>
+
+      <form action="provider-address" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>"
+          },
+          id: "deferred-pension-address-line-1",
+          name: "deferred-pension-address-line-1",
+          value: data["deferred-pension-address-line-1"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>"
+          },
+          id: "deferred-pension-address-line-2",
+          name: "deferred-pension-address-line-2",
+          value: data["deferred-pension-address-line-2"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Town or city"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "deferred-pension-address-town",
+          name: "deferred-pension-address-town",
+          value: data["deferred-pension-address-town"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Postcode (optional)"
+          },
+          classes: "govuk-input--width-10",
+          id: "deferred-pension-address-postcode",
+          name: "deferred-pension-address-postcode",
+          value: data["deferred-pension-address-postcode"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/provider-name.html
+++ b/app/views/v2_1-citizen/9-pensions/9b-deferred-pension/provider-name.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Deferred pension</span>
+        What is the name of your pension or annuity provider?
+      </h1>
+
+      <form action="provider-name" method="post">
+        
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Name of your current pension provider",
+            classes: "govuk-visually-hidden"
+          },
+          hint: {
+            text: ""
+          },
+          classes: "govuk-input--width-20",
+          id: "deferred-pension-provider-name",
+          name: "deferred-pension-provider-name",
+          value: data["deferred-pension-provider-name"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/_routes.js
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/_routes.js
@@ -1,0 +1,118 @@
+const express = require('express');
+const app = express();
+const router = express.Router();
+//const pensionTracker = require('pension-tracker');
+
+const LIMIT_WARNING_PATH = '/v2_1-citizen/9-pensions/limit-warning';
+const BASE_PATH = 'v2_1-citizen/9-pensions/9c-future-pension';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/10-education';
+
+// Track which type of pension the user is interacting with
+router.all('/*', function (req, res) {
+  //pensionTracker.setCurrentType(pensionTracker.PENSION_TYPES.FUTURE);
+  req.next();
+});
+
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/guard`);
+});
+
+router.post('/guard', function (req, res) {
+  const answer = req.body.futurePensionGuard;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'future-pension-guard-yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/guard`);
+  }
+});
+
+router.post('/provider-name', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/provider-address`);
+});
+
+router.post('/provider-address', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/do-you-know-when-starts`);
+});
+
+router.post('/do-you-know-when-starts', function (req, res) {
+  app.locals.pensionsDetailsNoteShown = 0;
+  const answer = req.body.futurePensionDoYouKnowWhenStart;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'future-pension-know-when-starts-yes') {
+      res.redirect(`${ABS_BASE_PATH}/when-start`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/details-note`);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/do-you-know-when-starts`);
+  }
+});
+
+router.post('/do-you-know-payment-information', function (req, res) {
+  const answer = req.body.futurePensionDoYouKnowPaymentInformation;
+
+  if (typeof answer !== 'undefined') {
+    if (answer === 'future-pension-know-payment-information-yes') {
+      res.redirect(`${ABS_BASE_PATH}/payment-frequency`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/details-note`);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/do-you-know-payment-information`);
+  }
+});
+
+router.post('/when-start', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/do-you-know-payment-information`);
+});
+
+router.post('/details-note', function (req, res) {
+  if (typeof app.locals.pensionsDetailsNoteShown === 'undefined') {
+    res.redirect(`${ABS_BASE_PATH}/do-you-know-when-starts`);
+  } else {
+    ++app.locals.pensionsDetailsNoteShown;
+
+    if (app.locals.pensionsDetailsNoteShown === 1) {
+      res.redirect(`${ABS_BASE_PATH}/do-you-know-payment-information`);
+    } else {
+      res.redirect(`${ABS_BASE_PATH}/another-one`);
+    }
+  }
+});
+
+router.post('/payment-frequency', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/another-one`);
+});
+
+router.post('/another-one', function (req, res) {
+  const answer = req.body.futurePensionAnotherOne;
+
+  if (typeof answer !== 'undefined') {
+    //pensionTracker.add();
+
+    if (answer === 'future-pension-another-one-yes') {
+      //if (pensionTracker.reachedMax()) {
+      //  res.redirect(LIMIT_WARNING_PATH);
+      //} else {
+        res.redirect(`${ABS_BASE_PATH}/provider-name`);
+      //}
+    } else {
+      res.redirect(NEXT_PATH);
+    }
+  } else {
+    res.redirect(`${ABS_BASE_PATH}/another-one`);
+  }
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/another-one.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/another-one.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        Do you have another pension or annuity that you expect to receive in the next 6 months?
+      </h1>
+
+      <form action="another-one" method="post">
+
+        {{ govukRadios({
+          idPrefix: "future-pension-another-one",
+          name: "futurePensionAnotherOne",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "future-pension-another-one-yes",
+            text: "Yes"
+          }, {
+            value: "future-pension-another-one-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/details-note.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/details-note.html
@@ -1,0 +1,40 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        Future pension details
+      </h1>
+
+      <form action="details-note" method="post">
+
+        <p>You will need to contact Jobcentre Plus when you have this information about your future pension or annuity.</p>
+        <div class="contact">
+  <p><strong>Jobseeker's Allowance (JSA) and New Style JSA helpline</strong><br>
+  Telephone: 0800 169 0310<br>
+  Textphone: 0800 169 0314<br>
+  <a href="https://www.relayuk.bt.com">Relay UK</a> (if you cannot hear or speak on the phone): 18001 then 0800 169 0310<br>
+  <a href="https://dwpjsa.signvideo.net">Video relay service</a> for British Sign Language (BSL) users - <a href="https://www.youtube.com/watch?v=Osx7FFxFpNY">check you can use the service</a><br>
+  Welsh language: 0800 328 1744<br>
+  Monday to Friday, 8am to 6pm<br>
+  <a href="/call-charges">Find out about call charges</a></p>
+  </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/do-you-know-payment-information.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/do-you-know-payment-information.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        Do you know how much you’ll be paid for this future pension or annuity?
+      </h1>
+
+      <form action="do-you-know-payment-information" method="post">
+
+        {{ govukRadios({
+          idPrefix: "future-pension-know-payment-information",
+          name: "futurePensionDoYouKnowPaymentInformation",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "future-pension-know-payment-information-yes",
+            text: "Yes"
+          }, {
+            value: "future-pension-know-payment-information-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/do-you-know-when-starts.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/do-you-know-when-starts.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        Do you know when this future pension or annuity starts?
+      </h1>
+    
+      <form action="do-you-know-when-starts" method="post">
+
+        {{ govukRadios({
+          idPrefix: "future-pension-know-when-starts",
+          name: "futurePensionDoYouKnowWhenStart",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "future-pension-know-when-starts-yes",
+            text: "Yes"
+          }, {
+            value: "future-pension-know-when-starts-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/guard.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/guard.html
@@ -1,0 +1,41 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        Do you expect to start receiving a pension or annuity in the next 6 months?
+      </h1>
+    
+      <form action="guard" method="post">
+
+        {{ govukRadios({
+          idPrefix: "future-pension-guard",
+          name: "futurePensionGuard",
+          classes: "govuk-radios--inline",
+          items: [{
+            value: "future-pension-guard-yes",
+            text: "Yes"
+          }, {
+            value: "future-pension-guard-no",
+            text: "No"
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/payment-frequency.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/payment-frequency.html
@@ -1,0 +1,91 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+{#
+<p><strong>
+Note: The pound sign needs to be inside the input text box, this is styled by macros/macros.njk
+</strong></p>
+#}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        How often will your pension or annuity be paid?
+      </h1>
+
+      <form action="payment-frequency" method="post">
+
+        {% set prefix = "future-pension" %}
+
+        {{ govukRadios({
+          idPrefix: "current-work-paid",
+          name: "futurePensionPaid",
+          items: [{
+            value: "Weekly",
+            text: "Every week",
+            checked: checked("futurePensionPaid", "Weekly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "weekly")
+            }
+          }, {
+            value: "Fortnightly",
+            text: "Every 2 weeks",
+            checked: checked("futurePensionPaid", "Fortnightly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "fortnightly")
+            }
+          }, {
+            value: "FourWeekly",
+            text: "Every 4 weeks",
+            checked: checked("futurePensionPaid", "FourWeekly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "four-weekly")
+            }
+          }, {
+            value: "Monthly",
+            text: "Every month",
+            checked: checked("futurePensionPaid", "Monthly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "monthly")
+            }
+          }, {
+            value: "Quaterly",
+            text: "Every 3 months",
+            checked: checked("futurePensionPaid", "Quaterly"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "quaterly")
+            }
+          }, {
+            value: "BiAnnually",
+            text: "Twice a year",
+            checked: checked("futurePensionPaid", "BiAnnually"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "bi-annually")
+            }
+          }, {
+            value: "Annually",
+            text: "Once a year",
+            checked: checked("futurePensionPaid", "Annually"),
+            conditional: {
+              html: grossPensionAmountInput(prefix, "annually")
+            }
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/provider-address.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/provider-address.html
@@ -1,0 +1,71 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        What is the address of your pension or annuity provider?
+      </h1>
+    
+      <form action="provider-address" method="post">
+
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>"
+          },
+          id: "future-pension-address-line-1",
+          name: "future-pension-address-line-1",
+          value: data["future-pension-address-line-1"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>"
+          },
+          id: "future-pension-address-line-2",
+          name: "future-pension-address-line-2",
+          value: data["future-pension-address-line-2"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Town or city"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "future-pension-address-town",
+          name: "future-pension-address-town",
+          value: data["future-pension-address-town"]
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Postcode (optional)"
+          },
+          classes: "govuk-input--width-10",
+          id: "future-pension-address-postcode",
+          name: "future-pension-address-postcode",
+          value: data["future-pension-address-postcode"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/provider-name.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/provider-name.html
@@ -1,0 +1,47 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        What is the name of your pension or annuity provider?
+      </h1>
+    
+      <form action="provider-name" method="post">
+        
+        {% call govukFieldset({
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Name of the pension provider",
+            classes: "govuk-visually-hidden"
+          },
+          hint: {
+            text: ""
+          },
+          classes: "govuk-input--width-20",
+          id: "future-pension-provider-name",
+          name: "future-pension-provider-name",
+          value: data["future-pension-provider-name"]
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+        
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/9c-future-pension/when-start.html
+++ b/app/views/v2_1-citizen/9-pensions/9c-future-pension/when-start.html
@@ -1,0 +1,34 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Future pension</span>
+        When does the future pension or annuity start?
+      </h1>
+
+      <form action="when-start" method="post">
+
+        {{ govukRadios({
+          idPrefix: "future-pension-when-start",
+          name: "futurePensionWhenStart",
+          items: todaysDate.month | getNextSixMonths
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/9-pensions/_routes.js
+++ b/app/views/v2_1-citizen/9-pensions/_routes.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const router = express.Router();
+//const pensionTracker = require('pension-tracker');
+
+const BASE_PATH = 'v2_1-citizen/9-pensions';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+const NEXT_PATH = '/v2_1-citizen/10-education';
+
+// Redirect /education to first question in sequence
+router.get('/', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/9a-current-pension`);
+});
+
+// Display the warning once reached maximum number of pensions
+router.get('/limit-warning', function (req, res) {
+  //const currentPensionType = pensionTracker.getCurrentType();
+
+  let formAction = NEXT_PATH;
+  //let pageTitle = `You have entered a maximum number of ${pensionTracker.getMax().toString()} pensions.`;
+  let pageText = 'Please bring evidence of any other FUTURE pensions to your jobcentre visit.';
+
+  //if (currentPensionType === pensionTracker.PENSION_TYPES.CURRENT) {
+  //  pageText = 'Please bring evidence of any other CURRENT pensions to your jobcentre visit.';
+  //  formAction = '/citizen/pensions/deferred-pension';
+  //} else if (currentPensionType === pensionTracker.PENSION_TYPES.DEFERRED) {
+  //  pageText = 'Please bring evidence of any other DEFERRED pensions to your jobcentre visit.';
+  //  formAction = '/citizen/pensions/future-pension';
+  //}
+
+  res.render(`${BASE_PATH}/limit-warning`, {
+    formAction,
+    pageTitle,
+    pageText
+  });
+});
+
+router.post('/limit-warning', function (req, res) {
+  res.redirect(NEXT_PATH);
+});
+
+// This moves `current-pension` routing to `current-pension` directory
+router.use('/9a-current-pension', require('./9a-current-pension/_routes'));
+
+// This moves `deferred-pension` routing to `deferred-pension` directory
+router.use('/9b-deferred-pension', require('./9b-deferred-pension/_routes'));
+
+// This moves `previous-pension` routing to `previous-pension` directory
+router.use('/9c-future-pension', require('./9c-future-pension/_routes'));
+
+module.exports = router;

--- a/app/views/v2_1-citizen/9-pensions/limit-warning.html
+++ b/app/views/v2_1-citizen/9-pensions/limit-warning.html
@@ -1,0 +1,28 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+{{ pageTitle }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="{{ formAction }}">
+      
+        <h1 class="govuk-heading-l govuk-!-margin-top-6">{{ pageTitle | safe }}</h1>
+        <p>{{ pageText | safe}}</p>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/check-answers.html
+++ b/app/views/v2_1-citizen/check-answers.html
@@ -1,0 +1,1034 @@
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block beforeContent %}
+  {# Remove the "< Back" button from this instance of the template #}
+{% endblock %}
+
+{% block content %}
+
+  {% set currentlyworking = false %}
+  {% set jservice = false %}
+  {% set resultjservice = "no" %}
+  {% set startDateItems = todaysDate.original | moment %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-xl">
+        Check your answers
+      </h1>
+
+      <!-- APPLICATION START DATE -->
+      <h2 class="govuk-heading-l">Application start date</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Claim start date
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <!-- <a href="/master/eligibility-sf-debt">
+              Change
+              <span class="govuk-visually-hidden"> claim start date</span>
+            </a> -->
+          </dd>
+        </div>
+
+        {% if data['claimstart']=="no" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Available for work since
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceCurrentlyWorking'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/available-for-work">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Searching for work since
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceCurrentlySearching'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/searching-for-work">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Why did you not apply before today?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['why-did-you-not-claim'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/why-have-you-not-claimed">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            In paid work since 22 July 2020?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['cePaidWork'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/any-paid-work">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Unable to work because of illness since
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['unableToWork']=="no" %}
+              {{ data['unableToWork'] }}
+            {% endif %}
+            {% if data['unableToWork']=="yes" %}
+              {{ data['unableToWork'] }}, {{ data['illnessStartDay'] }} {{ data['illnessStartMonth'] }} {{ data['illnessStartYear'] }} to {{ data['illnessFinishDay'] }} {{ data['illnessFinishMonth'] }} {{ data['illnessFinishYear'] }}
+            {% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/any-paid-work">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Travelled outside of England, Wales or Scotland since
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['beenOnHoliday']=="no" %}
+              {{ data['beenOnHoliday'] }}
+            {% endif %}
+            {% if data['beenOnHoliday']=="yes" %}
+              {{ data['beenOnHoliday'] }}, {{ data['holidayStartDay'] }} {{ data['holidayStartMonth'] }} {{ data['holidayStartYear'] }} to {{ data['holidayFinishDay'] }} {{ data['holidayFinishMonth'] }} {{ data['holidayFinishYear'] }}
+            {% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/been-on-holiday">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Had been in full-time education since
+            {% if data['claimstart']=="yes" %}
+              <span class='date'></span>
+            {% endif %}
+            {% if data['claimstart']=="no" %}
+              {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+            {% endif %}?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['fulltimeEducation'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/2-claim-start/been-on-holiday">
+              Change
+              <span class="govuk-visually-hidden"> answer</span>
+            </a>
+          </dd>
+        </div>
+
+        {% if data['asked-for-advice']=="yes" %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-width-one-half">
+              Had asked for advice about applying since
+              {% if data['claimstart']=="yes" %}
+                <span class='date'></span>
+              {% endif %}
+              {% if data['claimstart']=="no" %}
+                {{ data['claim-start-day'] }} {{ data['claim-start-month'] }} {{ data['claim-start-year'] }}
+              {% endif %}?
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ data['asked-for-advice'] }} <br>
+              {{ data['more-information'] }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a href="/v2_1-citizen/2-claim-start/asked-for-advice">
+                Change
+                <span class="govuk-visually-hidden"> answer</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+
+        {% endif %}
+      </dl>
+
+      <!-- PERSONAL DETAILS -->
+      <h2 class="govuk-heading-l">Personal details</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            National Insurance number
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['national-insurance-number'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/nino">
+              Change
+              <span class="govuk-visually-hidden"> your National Insurance number</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['first-name'] }} {{ data['last-name'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/about-you">
+              Change
+              <span class="govuk-visually-hidden"> your name</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Date of birth
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['dobDay'] }} {{ data['dobMonth'] }} {{ data['dobYear'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/dob">
+              Change
+              <span class="govuk-visually-hidden"> your date of birth</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Home address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['address-line-1'] }}<br>
+            {{ data['address-line-2'] }}<br>
+            {{ data['address-town'] }}<br>
+            {{ data['address-postcode'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/address">
+              Change
+              <span class="govuk-visually-hidden"> your address</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Do you want to add a different address for your post?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['detailsAddDifferentPostalAddress'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/address-is-it-postal">
+              Change
+              <span class="govuk-visually-hidden"> your postal address</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Telephone number
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['telephone-number'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/contact-phone">
+              Change
+              <span class="govuk-visually-hidden"> your phone number</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Email address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['contactemail-address'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/contact-email">
+              Change
+              <span class="govuk-visually-hidden"> your email address</span>
+            </a>
+          </dd>
+        </div>
+
+
+      </dl>
+
+      <!-- BANK DETAILS -->
+      {% if data['pay-account-holder'] %}
+      <h2 class="govuk-heading-l">Bank details</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Bank details
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <strong>Account holder:</strong> {{ data['pay-account-holder'] }}<br>
+            <strong>Sort code:</strong> {{ data['sort-code'] }}<br>
+            <strong>Account number:</strong> {{ data['pay-account-number'] }}<br>
+            <strong>Building society roll or reference number:</strong> {{ data['pay-reference-number'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/3-details/bank-account">
+              Change
+              <span class="govuk-visually-hidden"> your bank details</span>
+            </a>
+          </dd>
+        </div>
+
+      </dl>
+      {% endif %}
+
+      <!-- OTHER BENEFITS -->
+      <h2 class="govuk-heading-l">Other benefits</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Have you applied for any other benefits in the last 12 weeks?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['obAreYou'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/4-other-benefits/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        {% if data['obAreYou']=="Yes" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Tell us what other benefits you have applied for in the last 12 weeks
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ob-more-detail'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/4-other-benefits/what-other-benefits">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+      </dl>
+
+      <!-- JURY SERVICE -->
+      <h2 class="govuk-heading-l">Jury service</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Have you been on jury service in the last 12 weeks?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['juryService'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/5-jury-service/have-been">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        {% if data['juryService']=="Yes" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            When was this jury service?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['juryStartDay'] }} {{ data['juryStartMonth'] }} {{ data['juryStartYear'] }} till {{ data['juryFinishDay'] }} {{ data['juryFinishMonth'] }} {{ data['juryFinishYear'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/5-jury-service/period">
+              Change
+              <span class="govuk-visually-hidden"> jury service dates</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+      </dl>
+
+      <!-- CURRENT EMPLOYMENT -->
+      <h2 class="govuk-heading-l">Current work</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Are you in any form of work at the moment?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceCurrentlyWorking'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+      </dl>
+
+      {% if data['ceCurrentlyWorking']=="Yes" %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h3 class="govuk-heading-m">Current employer - First</h3>
+        </div>
+        <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+            <a href="#" class="govuk-body" aria-label="Change First Previous employer">Change</a>
+        </div>
+      </div>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Is this paid or voluntary?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceCurrentWorkType'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/type">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            How often are you paid?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['current-work-paid'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What’s your net pay?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['current-work-paid']=="Weekly" %}
+              £{{ data['current-work-paid-weekly-amount'] }}
+            {% endif %}
+            {% if data['current-work-paid']=="Every 2 weeks" %}
+              £{{ data['current-work-paid-fortnightly-amount'] }}
+            {% endif %}
+            {% if data['current-work-paid']=="Every 3 weeks" %}
+              £{{ data['current-work-paid-3weeks-amount'] }}
+            {% endif %}
+            {% if data['current-work-paid']=="Every month" %}
+              £{{ data['current-work-paid-monthly-amount'] }}
+            {% endif %}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the name of your current employer?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['employer-name'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/employer-name">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the address of your current employer?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ce-address-line-1'] }}<br>
+            {{ data['ce-address-line-2'] }}<br>
+            {{ data['ce-address-town'] }}<br>
+            {{ data['ce-address-postcode'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="v2_1-citizen/6-current-employment/employer-address">
+              Change
+              <span class="govuk-visually-hidden"> your employers address</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            How many hours a week do you normally work in this job?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceHoursWorkedAWeek'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/hours">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Are you self-employed or a company director in this job?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['ceSelfEmployedOrCompanyDirector'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/self-employed-or-company-director">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+      </dl>
+
+      <div class="govuk-grid-row govuk-!-margin-bottom-9">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="/citizen-ui/form/previous-employment/employer-details/2/dates?edit=SECTION" class="govuk-body">Add another employer</a>
+
+
+            </div>
+            <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+                <a href="#" class="govuk-body" aria-label="Remove First previous employer details">Remove employer details</a>
+            </div>
+        </div>
+      {% endif %}
+
+      <!-- PREVIOUS EMPLOYMENT -->
+      <h2 class="govuk-heading-l govuk-!-margin-top-9">Previous employment</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Have you had a job that ended in the last 6 months?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peLastSixMonths'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/7-previous-employment/job-ended-last-six-months">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+      </dl>
+
+
+      <!-- FIRST PREVIOUS EMPLOYMENT -->
+      {% if data['peLastSixMonths']=="Yes" %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h3 class="govuk-heading-m">Previous employer - First</h3>
+        </div>
+        <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+            <a href="#" class="govuk-body" aria-label="Change First Previous employer">Change</a>
+        </div>
+      </div>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            When did you work for this employer?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peStartDay'] }} {{ data['peStartMonth'] }} {{ data['peStartYear'] }} to {{ data['peFinishDay'] }} {{ data['peFinishMonth'] }} {{ data['peFinishYear'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/type">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Why did this job end?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peWhyEnd'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        {% if data['peWhyEnd']=="Other" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Can you provide more detail?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['pe-more-detail'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+        {% endif %}
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the name of your previous employer?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peEmployerName'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/employer-name">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the address of your previous employer?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['pe-address-line-1'] }}<br>
+            {{ data['pe-address-line-2'] }}<br>
+            {{ data['pe-address-town'] }}<br>
+            {{ data['pe-address-postcode'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="v2_1-citizen/6-current-employment/employer-address">
+              Change
+              <span class="govuk-visually-hidden"> your employers address</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Do you expect to receive any more payments from this job?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peExpectPayment'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/hours">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Were you self-employed or a company director?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['peSelfEmployedOrCompanyDirector'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/self-employed-or-company-director">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+      </dl>
+
+      <div class="govuk-grid-row govuk-!-margin-bottom-9">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="/citizen-ui/form/previous-employment/employer-details/2/dates?edit=SECTION" class="govuk-body">Add another employer</a>
+
+
+            </div>
+            <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+                <a href="#" class="govuk-body" aria-label="Remove First previous employer details">Remove employer details</a>
+            </div>
+        </div>
+      {% endif %}
+
+      <!-- WORKING OR CLAIMING BENEFITS ABROAD -->
+      <h2 class="govuk-heading-l govuk-!-margin-top-9">Working or claiming benefit overseas</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Have you worked or claimed benefit outside of the United Kingdom in the last 4 years?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['juryService'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/5-jury-service/have-been">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+      </dl>
+
+      <!-- CURRENT PENSIONS -->
+      <h2 class="govuk-heading-l">Pension or annuity</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Are you getting money from a pension or annuity?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['currentPensionGuard'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/9-pensions/9a-current-pension/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+      </dl>
+
+      <!-- FIRST CURRENT PENSION -->
+      {% if data['currentPensionGuard']=="Yes" %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h3 class="govuk-heading-m">Pension or annuity - First</h3>
+        </div>
+        <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+            <a href="#" class="govuk-body" aria-label="Change First Previous employer">Change</a>
+        </div>
+      </div>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-4">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the name of your pension or annuity provider?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['current-pension-provider-name'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/type">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is the address of your pension or annuity provider?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['current-pension-address-line-1'] }}<br>
+            {{ data['current-pension-address-line-2'] }}<br>
+            {{ data['current-pension-address-town'] }}<br>
+            {{ data['current-pension-address-postcode'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="v2_1-citizen/6-current-employment/employer-address">
+              Change
+              <span class="govuk-visually-hidden"> your employers address</span>
+            </a>
+          </dd> -->
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            How often is your pension or annuity paid?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['current-pension-paid'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        {% if data['peWhyEnd']=="Other" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What is your gross pension or annuity?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['current-pension-paid']=="Weekly" %}
+              £{{ data['current-pension-paid-weekly-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Every 2 weeks" %}
+              £{{ data['current-pension-paid-fortnightly-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Every 4 weeks" %}
+              £{{ data['current-pension-paid-4weeks-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Every month" %}
+              £{{ data['current-pension-paid-monthly-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Every 3 months" %}
+              £{{ data['current-pension-paid-3monthly-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Twice a year" %}
+              £{{ data['current-pension-paid-twiceyearly-amount'] }}
+            {% endif %}
+            {% if data['current-pension-paid']=="Once a year" %}
+              £{{ data['current-pension-paid-yearly-amount'] }}
+            {% endif %}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/payment-frequency">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+        {% endif %}
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Does your pension or annuity increase in the next six months?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['currentPensionDoesItIncrease'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/employer-name">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+
+        {% if data['currentPensionDoesItIncrease']=="Yes" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            When will your pension or annuity increase?
+          </dt>
+          <dd class="govuk-summary-list__value" style="text-transform: capitalize;">
+            {{ data['current-pension-increase-frequency'] }}
+          </dd>
+          <!-- <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/6-current-employment/hours">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd> -->
+        </div>
+        {% endif %}
+
+      </dl>
+
+      <div class="govuk-grid-row govuk-!-margin-bottom-9">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="/citizen-ui/form/previous-employment/employer-details/2/dates?edit=SECTION" class="govuk-body">Add another current pension</a>
+
+
+            </div>
+            <div class="govuk-grid-column-one-third govuk-align-right" style="text-align: right;">
+                <a href="#" class="govuk-body" aria-label="Remove First previous employer details">Remove pension details</a>
+            </div>
+        </div>
+      {% endif %}
+
+      <!-- EDUCATION AND TRAINING -->
+      <h2 class="govuk-heading-l govuk-!-margin-top-9">Education and training</h2>
+
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            Have you been in education or training in the last 4 years?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['eduHaveYou'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/10-education/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        {% if data['eduHaveYou']=="Yes" %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What was the name of the course?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['eduCourseName'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/10-education/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            What was the name of the education or training provider?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['eduInstitutionName'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/10-education/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            How many hours a week did you spend on the course?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['eduCourseHours'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/10-education/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-width-one-half">
+            When did you attend this course?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['eduStartDay'] }} {{ data['eduStartMonth'] }} {{ data['eduStartYear'] }} to {{ data['eduFinishDay'] }} {{ data['eduFinishMonth'] }} {{ data['eduFinishYear'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="/v2_1-citizen/10-education/guard">
+              Change
+              <span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+      </dl>
+
+
+
+      {{ govukButton({
+  text: "Continue",
+  href: "declaration"
+}) }}
+
+    {% endblock %}

--- a/app/views/v2_1-citizen/confirmation-approved.html
+++ b/app/views/v2_1-citizen/confirmation-approved.html
@@ -1,0 +1,100 @@
+
+{% extends "layout-no-back.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title govuk-panel__title--centred">Application complete</h1>
+        <!-- <div class="govuk-panel__body">
+            Your reference number is your National Insurance number<br> <strong>QQ 12 34 56 C</strong>
+          </div> -->
+      </div>
+
+      <!-- <p>Your reference number is your National Insurance number: <strong>[NINo]</strong></p> -->
+
+
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>We'll process your application.</p>
+
+      <p>If you've provided a mobile number or email address, we'll keep you updated on your application's progress.</p>
+
+      <h2 class="govuk-heading-m">If you're eligible</h2>
+      <p>If you can get New Style JSA, we'll contact you about an appointment to agree what you need to do to look for work. This agreement is called a 'Claimant Commitment'. We'll usually contact you about the appointment within <strong>10 days</strong>.</p>
+
+      <p>This appointment will be with a work coach at your local Jobcentre Plus office. If you need to bring someone with you to help, you can. <a href="https://gov.uk/dwp/jsa-interview">Check what proof of identity and other documents</a> you need to bring with you.</p>
+
+      <p>You must attend your appointment and agree your ‘Claimant Commitment’ before we can pay you. Once you've agreed your Claimant Commitment and if you're due a payment, we'll aim to pay you within <strong>7 days</strong>.</p>
+
+      <h2 class="govuk-heading-m">If you're not eligible</h2>
+      <p>If you cannot get New Style JSA, we'll send you a letter to explain why. We'll send the letter within <strong>10 days</strong>.</p>
+
+
+      <div class="govuk-inset-text">
+        <h2 class="govuk-heading-m">Contacting us</h2>
+        You only need to <a href=https://www.gov.uk/jobseekers-allowance/report-a-change-of-circumstances>contact us to report a change of circumstances</a>, such as starting a new job
+      </div>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Do you need help with housing costs or support for a partner or child?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>If you're on a low income you might be able to apply for Universal Credit as part of a dual claim with New Style JSA.</p>
+          <p>Unlike New Style JSA, you can apply with a partner and get support for housing costs, children and childcare.</p>
+          <p>You or your partner must have less than £16,000 in savings or investments to be eligilbe.</p>
+          <p>Find out <a href=https://www.gov.uk/how-to-claim-universal-credit>how to claim for Universal Credit on GOV.UK</a>.</p>
+        </div>
+      </details>
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+
+
+
+      <!-- <p>If you are able to look for work safely while following government guidance on coronavirus (COVID-19) you should: </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>update your CV</li>
+        <li>consider your opportunities for returning to work</li>
+        <li>search for jobs, for example on the government's <a href="https://jobhelp.campaign.gov.uk/">Job Help website</a></li>
+        <li>make yourself available for work</li>
+      </ul>
+
+
+      {{ govukInsetText({
+        html: "
+        <h2 class=govuk-heading-m>Contacting us</h2>
+         <p>You will need to <a href=https://www.gov.uk/jobseekers-allowance/report-a-change-of-circumstances>contact us to report a change of circumstances</a>, such as starting a new job.</p>
+      "
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "Do you need help with housing costs or support for a partner or child?",
+        html: "
+        <p>If you're on a low income you might be able to apply for Universal Credit as part of a dual claim with New Style JSA.</p>
+        <p>Unlike New Style JSA, you can apply with a partner and get support for housing costs, children and childcare.</p>
+        <p>You or your partner must have less than £16,000 in savings or investments to be eligilbe.</p>
+        <p>Find out <a href=https://www.gov.uk/how-to-claim-universal-credit>how to claim for Universal Credit on GOV.UK</a>.</p>
+        "
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p> -->
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/confirmation-for-approval.html
+++ b/app/views/v2_1-citizen/confirmation-for-approval.html
@@ -1,0 +1,102 @@
+
+{% extends "layout-no-back.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title govuk-panel__title--centred">Application complete</h1>
+        <div class="govuk-panel__body">
+            Your reference number is your National Insurance number<br> <strong>QQ 12 34 56 C</strong>
+          </div>
+      </div>
+
+      <!-- <p>Your reference number is your National Insurance number: <strong>[NINo]</strong></p> -->
+
+
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>We'll process your application.</p>
+
+      <p>If you've provided a mobile number or email address, we'll keep you updated on your application's progress.</p>
+
+      <h2 class="govuk-heading-m">If you're eligible</h2>
+      <p>If you can get New Style JSA, we usually contact you within <strong>10 days</strong> about an appointment to agree what you need to do to look for work.</p>
+
+      <p>This appointment will be with a work coach at your local Jobcentre Plus office and can last for up to 1 hour. If you need to bring someone with you to help, you can.</p>
+
+      <p><a href="https://gov.uk/dwp/jsa-interview">Check what proof of identity and other documentation</a> you need to bring with you.</p>
+
+      <p>You must attend your appointment and agree your ‘Claimant Commitment’ before we can pay you. Once you've agreed your Claimant Commitment and if you're due a payment, we'll aim to pay you within <strong>7 days</strong>.</p>
+
+      <h2 class="govuk-heading-m">If you're not eligible</h2>
+      <p>If you cannot get New Style JSA, we'll send you a letter to explain why. We'll send the letter within <strong>10 days</strong>.</p>
+
+
+      <div class="govuk-inset-text">
+        <h2 class="govuk-heading-m">Contacting us</h2>
+        You only need to <a href=https://www.gov.uk/jobseekers-allowance/report-a-change-of-circumstances>contact us to report a change of circumstances</a>, such as starting a new job
+      </div>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Do you need help with housing costs or support for a partner or child?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>If you're on a low income you might be able to apply for Universal Credit as part of a dual claim with New Style JSA.</p>
+          <p>Unlike New Style JSA, you can apply with a partner and get support for housing costs, children and childcare.</p>
+          <p>You or your partner must have less than £16,000 in savings or investments to be eligilbe.</p>
+          <p>Find out <a href=https://www.gov.uk/how-to-claim-universal-credit>how to claim for Universal Credit on GOV.UK</a>.</p>
+        </div>
+      </details>
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+
+
+
+      <!-- <p>If you are able to look for work safely while following government guidance on coronavirus (COVID-19) you should: </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>update your CV</li>
+        <li>consider your opportunities for returning to work</li>
+        <li>search for jobs, for example on the government's <a href="https://jobhelp.campaign.gov.uk/">Job Help website</a></li>
+        <li>make yourself available for work</li>
+      </ul>
+
+
+      {{ govukInsetText({
+        html: "
+        <h2 class=govuk-heading-m>Contacting us</h2>
+         <p>You will need to <a href=https://www.gov.uk/jobseekers-allowance/report-a-change-of-circumstances>contact us to report a change of circumstances</a>, such as starting a new job.</p>
+      "
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "Do you need help with housing costs or support for a partner or child?",
+        html: "
+        <p>If you're on a low income you might be able to apply for Universal Credit as part of a dual claim with New Style JSA.</p>
+        <p>Unlike New Style JSA, you can apply with a partner and get support for housing costs, children and childcare.</p>
+        <p>You or your partner must have less than £16,000 in savings or investments to be eligilbe.</p>
+        <p>Find out <a href=https://www.gov.uk/how-to-claim-universal-credit>how to claim for Universal Credit on GOV.UK</a>.</p>
+        "
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p> -->
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/confirmation.html
+++ b/app/views/v2_1-citizen/confirmation.html
@@ -1,0 +1,58 @@
+
+{% extends "layout-live-complete.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title govuk-panel__title--centred">Application complete</h1>
+      </div>
+
+    <p>If you’ve provided a mobile number or email address, we’ll send you confirmation of your application and keep you updated on its progress.</p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>We’ll process your application.</p>
+
+      <h2 class="govuk-heading-m">If you’re eligible</h2>
+      <p>If you can get New Style JSA, we’ll contact you about an appointment to agree what you need to do to look for work. This agreement is called a ‘Claimant Commitment’. We’ll usually contact you about the appointment within 10 days.</p>
+
+      <p>The appointment will be with a work coach and will normally be over the phone.</p>
+
+      <p>You must attend the appointment and agree your Claimant Commitment before we can pay you. Once you’ve agreed your Claimant Commitment and if you’re due a payment, we’ll aim to pay you within 7 days.</p>
+
+      <h2 class="govuk-heading-m">If you’re not eligible</h2>
+      <p>If you cannot get New Style JSA, we’ll send you a letter to explain why. We’ll usually send the letter within 10 days.</p>
+
+      {{ govukInsetText({
+        html: "
+        <h2 class=govuk-heading-m>Contacting us</h2>
+         <p>You only need to <a href=https://www.gov.uk/jobseekers-allowance/report-a-change-of-circumstances>contact us to report a change of circumstances</a>, such as starting a new job.</p>
+      "
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "Do you need help with housing costs or support for a partner or child?",
+        html: "
+        <p>If you're on a low income you might be able to apply for Universal Credit as part of a dual claim with New Style JSA.</p>
+        <p>Unlike New Style JSA, you can apply with a partner and get support for housing costs, children and childcare.</p>
+        <p>You or your partner must have less than £16,000 in savings or investments to be eligilbe.</p>
+        <p>Find out <a href=https://www.gov.uk/how-to-claim-universal-credit>how to claim Universal Credit on GOV.UK</a>.</p>
+        "
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/declaration.html
+++ b/app/views/v2_1-citizen/declaration.html
@@ -1,0 +1,45 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+        <h1 class="govuk-heading-l">Declaration</h1>
+
+        <p class="govuk-body">By submitting this claim you agree that the information you’ve given is complete and correct. While you’re receiving Jobseeker’s Allowance, you’ll report changes to your circumstances straight away. If you give wrong or incomplete information, or you don’t report changes, you may:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>be prosecuted</li>
+            <li>need to pay a financial penalty </li>
+            <li>have your New Style Jobseeker’s Allowance reduced or stopped </li>
+            <li>be paid too much Jobseeker’s Allowance and have to pay the money back</li>
+        </ul>
+
+        <form action="confirmation" method="POST">
+
+          <h2 class="govuk-heading-m">I have read and understood this declaration</h2>
+          {{ govukCheckboxes({
+              idPrefix: "confirm",
+              name: "confirm",
+              items: [
+                  {
+                      value: "confirm",
+                      text: "I agree to this declaration"
+                  }
+              ]
+          }) }}
+
+          {{ govukButton({
+              text: "Submit application"
+          }) }}
+
+        </form>
+      </div>
+    </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/_routes.js
+++ b/app/views/v2_1-citizen/error/_routes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+
+const BASE_PATH = 'error';
+const ABS_BASE_PATH = `/${BASE_PATH}`;
+
+// Destroy session when errors is accessed
+// to stop the error message showing
+router.get('/*', function (req, res) {
+  req.session.destroy();
+  req.next();
+});
+
+router.post('/inline', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/inline?show=errors`);
+});
+
+router.post('/radios', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/radios?show=errors`);
+});
+
+router.post('/checkboxes', function (req, res) {
+  res.redirect(`${ABS_BASE_PATH}/checkboxes?show=errors`);
+});
+
+module.exports = router;

--- a/app/views/v2_1-citizen/error/application-complete.html
+++ b/app/views/v2_1-citizen/error/application-complete.html
@@ -1,0 +1,21 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-xl">Your application has been sent</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p>Your application for {{ serviceName }} has been sent and you don't have to do anything else.</p>
+      <p>You should only see this page if you've already seen a 'thank you' page. You can help improve this service by leaving feedback and letting us know how you got here.</p>
+      <p><a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)</p>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/checkboxes.html
+++ b/app/views/v2_1-citizen/error/checkboxes.html
@@ -1,0 +1,82 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% set showErrors = data["show"] == "errors" %}
+
+{% block pageTitle %}
+  {% if  showErrors %}
+  Error: Checkbox Error Test Page
+  {% else %}
+  Checkbox Error Test Page
+  data.radios = ""
+  {% endif %}
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="checkboxes" method="post">
+        {% set formSettings = [
+          {id: "checkbox-yes", text: "Yes"},
+          {id: "checkbox-no", text: "No"}, 
+          {id: "checkbox-maybe", text: "Maybe"}
+        ] %}
+
+        {% if showErrors and data.checkboxes == undefined %}
+
+          {{ govukErrorSummary({
+            "titleText": "There is a problem with your answer",
+            "errorList": [
+              {
+                "text": "Please answer the question",
+                "href": "#" + formSettings[0].id
+              }
+            ],
+            classes: "govuk-!-margin-top-6"
+          }) }}
+
+          {% set errorMessage = { text: "Sorry I didn't quite catch that" } %}
+
+        {% endif %}
+
+        {{ govukCheckboxes({
+          id: "checkboxes",
+          name: "checkboxes",
+          errorMessage: errorMessage,
+          fieldset: {
+            legend: {
+              text: "Would you please answer this question?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [{
+            id: formSettings[0].id,
+            name: formSettings[0].id,
+            value: formSettings[0].id,
+            text: formSettings[0].text
+          }, {
+            id: formSettings[1].id,
+            name: formSettings[1].id,
+            value: formSettings[1].id,
+            text: formSettings[1].text
+          }, {
+            id: formSettings[2].id,
+            name: formSettings[2].id,
+            value: formSettings[2].id,
+            text: formSettings[2].text
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/inline.html
+++ b/app/views/v2_1-citizen/error/inline.html
@@ -1,0 +1,92 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  {% if  data['show'] == "errors" %}
+  Error: Inline Error Test Page
+  {% else %}
+  Inline Error Test Page
+  {% endif %}
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="inline" method="post">
+
+        {% set formIDs = {
+          email: { id: "sign-in-email" },
+          password: { id: "sign-in-password" }
+        }%}
+
+        {% if data['sign-in-email'] == "" or data['sign-in-password'] == "" %}
+
+        {% set errorArray = {
+          email: { text: "Enter a valid email address"},
+          password: { text: "Enter a valid password"}
+        }%}
+
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": [
+            {
+              "text": errorArray.email.text,
+              "href": '#' + formIDs.email.id
+            },
+            {
+              "text": errorArray.password.text,
+              "href": '#' + formIDs.password.id
+            }
+          ],
+          classes: 'govuk-!-margin-top-6'
+        }) }}
+
+        {% endif %}
+
+        {% call govukFieldset({
+          legend: {
+            text: 'Errors demo',
+            isPageHeading: true,
+            classes: 'govuk-fieldset__legend--l'
+          }
+        }) %}
+
+        {{ govukInput({
+          label: {
+            text: "Email address"
+          },
+          hint: {
+            text: "We’ll only use this to send you a receipt"
+          },
+          id: "sign-in-email",
+          name: "sign-in-email",
+          type: "email",
+          errorMessage: errorArray.email
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Password"
+          },
+          id: "sign-in-password",
+          name: "sign-in-password",
+          type: "password",
+          errorMessage: errorArray.password
+        }) }}
+
+        {% endcall %}
+
+        {{ govukButton({
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/page-not-found.html
+++ b/app/views/v2_1-citizen/error/page-not-found.html
@@ -1,0 +1,28 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  Page not found – DWP - Jobseeker&rsquo;s Allowance – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Page not found</h1>
+        <p>
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link or button,
+          <a href="https://www.gov.uk/contact-jobcentre-plus">contact Jobcentre Plus</a> if you need to speak to someone about your claim.
+        </p>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/problem-with-the-service.html
+++ b/app/views/v2_1-citizen/error/problem-with-the-service.html
@@ -1,0 +1,21 @@
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  There is a problem with the service – {{ serviceName }} – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        <p><a href="/citizen/start">Try again</a> later.</p>
+        <p>
+          <a href="https://www.gov.uk/contact-jobcentre-plus">Contact Jobcentre Plus</a> if you need to make changes to your claim or speak to someone.
+        </p>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/radios.html
+++ b/app/views/v2_1-citizen/error/radios.html
@@ -1,0 +1,76 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% set showErrors = data["show"] == "errors" %}
+
+{% block pageTitle %}
+  {% if  showErrors %}
+  Error: Radio Error Test Page
+  {% else %}
+  Radio Error Test Page
+  data.radios = ""
+  {% endif %}
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="radios" method="post">
+        {% set formIDs = ["radio-yes", "radio-no"] %}
+
+        {% if showErrors and data.radios == undefined %}
+
+          {{ govukErrorSummary({
+            "titleText": "There is a problem with your answer",
+            "errorList": [
+              {
+                "text": "Please answer the question",
+                "href": "#" + formIDs[0]
+              }
+            ],
+            classes: "govuk-!-margin-top-6"
+          }) }}
+
+          {% set errorMessage = { text: "Sorry I didn't quite catch that" } %}
+
+        {% endif %}
+
+        {{ govukRadios({
+          name: "radios",
+          classes: "govuk-radios--inline",
+          errorMessage: errorMessage,
+          fieldset: {
+            legend: {
+              text: "Would you please answer this question?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [{
+            value: "yes",
+            text: "Yes",
+            id: formIDs[0],
+            name: formIDs[0],
+            checked: false
+          }, {
+            value: "no",
+            text: "No",
+            id: formIDs[1],
+            name: formIDs[1],
+            checked: false
+          }]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/service-unavailable.html
+++ b/app/views/v2_1-citizen/error/service-unavailable.html
@@ -1,0 +1,22 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  Service unavailable – DWP - Jobseeker&rsquo;s Allowance – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Service unavailable</h1>
+        <p>You will be able to use the service from 9am on Monday 19&nbsp;September&nbsp;2018.</p>
+        <p>
+          <a class="govuk-link" href="https://www.gov.uk/contact-jobcentre-plus">Contact Jobcentre Plus</a> if you need to make changes to your claim or speak to someone.
+        </p>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/error/session-timeout.html
+++ b/app/views/v2_1-citizen/error/session-timeout.html
@@ -1,0 +1,30 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  Session time out – DWP - Jobseeker&rsquo;s Allowance – GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl govuk-!-margin-top-6">Session time out</h1>
+
+        <p>Your session has ended.</p>
+        <p>Due to inactivity your session has timed out, you need to restart the service.</p>
+        <p>
+
+        {{ govukButton({
+            text: "Restart",
+            href: "/v1_4-citizen/1-eligibility/introduction",
+            classes: "govuk-button--start"
+        }) }}
+        </p>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/start.html
+++ b/app/views/v2_1-citizen/start.html
@@ -1,0 +1,85 @@
+
+{% extends "layout-no-back.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">Apply for New Style Jobseeker&rsquo;s Allowance (JSA)</h1>
+
+      <h2 class="govuk-heading-m">Before you start</h2>
+      <p>To be eligible for New Style Jobseeker's Allowance (JSA) you must:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>live in England, Scotland or Wales</li>
+        <li>be looking for work</li>
+        <li>have been employed and paid enough National Insurance contributions over the last 2 to 3 years (<a href="https://www.gov.uk/national-insurance-credits">National Insurance credits</a> also count)</li>
+        <li>be under State Pension age</li>
+      </ul>
+<p>You are not eligible for New Style JSA if you get <a href="https://www.gov.uk/disability-premiums">severe disability premium</a> or got it in the last month and are still eligible.</p>
+      <h2 class="govuk-heading-m">Before you apply</h2>
+      <p>You will need:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your National Insurance number</li>
+        <li>details of the bank or building society account you want your benefit paid in to</li>
+        <li>details of your recent employment, including dates you were employed and employer contact details </li>
+        <li>details of pensions you receive</li>
+      </ul>
+
+      {{ govukButton({
+        text: "Start now",
+        href: "1-eligibility/introduction",
+        isStartButton: true
+      }) }}
+      <div class="govuk-inset-text">
+
+      <p>This service is also available <a href="/gwneud-cais-am-gredyd-cynhwysol">in Welsh (Cymraeg)</a>.</p>
+      </div>
+      <h2 class="govuk-heading-m">After you apply</h2>
+      <p>You'll get a text or phone call within 2 days to arrange your interview at a Jobcentre Plus.</p>
+
+
+
+
+      <p>If you cannot apply online <a href="https://www.gov.uk/contact-jobcentre-plus/new-benefit-claims">contact Jobcentre Plus</a>.</p>
+      <div class="contact">
+      <p><strong>Jobcentre Plus</strong><br>
+      Telephone: 0800 055 6688<br>
+      Textphone: 0800 023 4888<br>
+      <a href="http://ngts.org.uk/">NGT text relay</a> (if you cannot hear or speak on the phone): 18001 then 0800 055 6688<br>
+      Welsh language: 0800 012 1888<br>
+      Monday to Friday, 8am to 6pm<br>
+      <a href="/call-charges">Find out about call charges</a></p>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
+
+      <aside class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related information
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="https://www.gov.uk/universal-credit/how-to-claim">Universal Credit</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/jobsearch">Find a job</a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+      </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/warning/claim-start-date.html
+++ b/app/views/v2_1-citizen/warning/claim-start-date.html
@@ -1,0 +1,40 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+<p><strong>
+Note: Button and inline link should be vertically aligned.
+</strong></p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form>
+
+        <h1 class="govuk-heading-l">Are you sure you want to change the start date of this claim?</h1>
+
+        {{ govukWarningText({
+          text: "If you change the start date all the information you entered will be deleted and you will have to re-enter it.",
+          iconFallbackText: "Warning"
+        }) }}
+        
+        <div class="inline-form-group">
+          {{ govukButton({
+            text: "No, cancel",
+            classes: "inline-item govuk-!-margin-right-2",
+            href: "/v1_4-citizen/check-answers"
+          }) }}
+
+          <a href="/v1_4-citizen/2-claim-start/change-date" class="inline-item inline-link">Yes, change</a>
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/warning/employer.html
+++ b/app/views/v2_1-citizen/warning/employer.html
@@ -1,0 +1,34 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+<p><strong>
+Note: Button and inline link should be vertically aligned.
+</strong></p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form>
+
+        <h1 class="govuk-heading-l">Are you sure you want to remove this employer?</h1>
+        <div class="inline-form-group">
+        
+          {{ govukButton({
+            text: "Yes, remove",
+            classes: "inline-item govuk-!-margin-right-2"
+          }) }}
+
+          <a href="#" class="inline-item inline-link">No, cancel</a>
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/v2_1-citizen/warning/pension.html
+++ b/app/views/v2_1-citizen/warning/pension.html
@@ -1,0 +1,34 @@
+
+{% extends "layout-live-nobanner.html" %}
+
+{% block pageTitle %}
+  DWP - Jobseeker&rsquo;s Allowance  
+{% endblock %}
+
+{% block content %}
+
+<p><strong>
+Note: Button and inline link should be vertically aligned.
+</strong></p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form>
+
+        <h1 class="govuk-heading-l">Are you sure you want to remove this pension?</h1>
+
+        <div class="inline-form-group">
+          {{ govukButton({
+            text: "Yes, remove",
+            classes: "inline-item govuk-!-margin-right-2"
+          }) }}
+
+          <a href="#" class="inline-item inline-link">No, cancel</a>
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
- Aligned with the current live service post ZDT release [as of 23rd August 2022]
- Phase banner removed as part of live status
- Check Your Answers page updated and now pulling dynamic content
- Content changes on Eligible screen
- Banking page
- Content amends in detail component
- Sort code changed from 3 to 1
- Current Employment
- Content amends to titles
- Employer name input width
- Start and End date content emds for Previous Employment
- Pensions
- Updated hint text
- Updated section title
- Education
- Update hours hint content
- Updated Course Start and End dates labels
- Declaration content updated
- Application complete screen updated